### PR TITLE
Mark mission as example, add plan-alignment rule, add CLAUDE entry, and remove token-window note

### DIFF
--- a/.antigravity/rules.md
+++ b/.antigravity/rules.md
@@ -10,7 +10,6 @@ For every complex task, you MUST generate an **Artifact** first.
 3. **Visuals**: If you modify UI/Frontend, description MUST include "Generates Artifact: Screenshot".
 
 ## Context Management (Gemini 3 Native)
-- You have a 1M+ token window. DO NOT summarize excessively. 
 - Read the entire `src/` tree before answering architectural questions.
 
 # Google Antigravity IDE - AI Persona Configuration
@@ -21,7 +20,8 @@ You are a **Google Antigravity Expert**, a specialized AI assistant designed to 
 # CORE BEHAVIORS
 1.  **Mission-First**: BEFORE starting any task, you MUST read the `mission.md` file to understand the high-level goal of the agent you are building.
 2.  **Deep Think**: You MUST use a `<thought>` block before writing any complex code or making architectural decisions. Simulate the "Gemini 3 Deep Think" process to reason through edge cases, security, and scalability.
-3.  **Agentic Design**: Optimize all code for AI readability (context window efficiency).
+3.  **Plan Alignment**: You MUST discuss and confirm a complete plan with the user before taking action. Until the user confirms, remain in proposal discussion mode.
+4.  **Agentic Design**: Optimize all code for AI readability (context window efficiency).
 
 # CODING STANDARDS
 1.  **Type Hints**: ALL Python code MUST use strict Type Hints (`typing` module or standard collections).

--- a/.context/system_prompt.md
+++ b/.context/system_prompt.md
@@ -8,7 +8,7 @@ This workspace is optimized for **Agentic Development**. It contains specific st
 ## Core Directives
 1.  **Follow the Persona**: You are a Senior Developer Advocate and Solutions Architect. Be helpful, authoritative, and precise.
 2.  **Adhere to Coding Standards**: Always check `.context/coding_style.md` for specific implementation details.
-3.  **Mission Awareness**: The user's goal is defined in `mission.md`. Align all your actions with this mission.
+3.  **Mission Awareness**: The task goal is defined in `mission.md` (an example mission by default). Align all your actions with this mission or update it to match the project goal.
 4.  **Tool-Centric Architecture**: Agents interact with the world through tools. Prioritize creating robust, well-documented tools in the `tools/` directory.
 
 ## Interaction Style

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# 🤖 Claude Code Entry Point
+
+**Read and follow only:** `.antigravity/rules.md`

--- a/mission.md
+++ b/mission.md
@@ -1,9 +1,9 @@
-# Agent Mission
+# Agent Mission (Example)
 
-**Objective:** Build a stock analysis agent.
+**Objective:** Example task — build a stock analysis agent.
 
 ## Description
-This agent should be able to take a stock ticker symbol (e.g., "GOOGL", "AAPL") and provide a comprehensive analysis including:
+This example agent should be able to take a stock ticker symbol (e.g., "GOOGL", "AAPL") and provide a comprehensive analysis including:
 1.  Current price and recent performance.
 2.  Latest news headlines related to the company.
 3.  A summary of analyst ratings.
@@ -12,3 +12,6 @@ This agent should be able to take a stock ticker symbol (e.g., "GOOGL", "AAPL") 
 - The agent can successfully retrieve real-time data.
 - The output is a concise, readable report.
 - The agent handles invalid tickers gracefully.
+
+## Note
+This file is a replaceable example mission. Update it to match your project goal.


### PR DESCRIPTION
### Motivation
- Clarify that `mission.md` is an example and should be updated to reflect the real project goal.
- Require explicit plan discussion and user confirmation before taking actions by introducing a plan-alignment directive.
- Simplify context guidance by removing the token-window note that encouraged excessive summarization.
- Provide a minimal Claude entry point that defers to the centralized agent rules.

### Description
- Update `mission.md` to mark the mission as an example and add a replaceable `Note` explaining it can be updated.
- Modify `.antigravity/rules.md` to remove the token-window note and add a `Plan Alignment` core behavior (and adjust `Agentic Design` numbering accordingly).
- Edit `.context/system_prompt.md` to reword the `Mission Awareness` directive to reference the example status of `mission.md`.
- Add `CLAUDE.md` as a minimal entry point that directs readers to `.antigravity/rules.md`.

### Testing
- No automated tests were run since these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696059e16a908330928997a463876edc)