### PR TITLE
fix: ensure google-genai installed in install scripts

### DIFF
--- a/artifacts/plan_install_google_genai.md
+++ b/artifacts/plan_install_google_genai.md
@@ -1,0 +1,17 @@
+# Plan: Ensure google-genai is installed by installers
+
+## Goal
+Update install scripts to explicitly ensure the correct Google GenAI SDK is installed so Windows users do not hit `ModuleNotFoundError: No module named 'google'`.
+
+## Steps
+1. Review current install scripts and dependency list.
+2. Add a post-install check to uninstall `google-generativeai` if present and install/verify `google-genai`.
+3. Keep messages user-friendly and non-failing if the old package is absent.
+4. Verify scripts remain consistent across Linux/macOS and Windows.
+
+## Files
+- install.sh
+- install.bat
+
+## Notes
+- No code changes in src/ required.

--- a/install.bat
+++ b/install.bat
@@ -76,6 +76,19 @@ if errorlevel 1 (
 )
 echo ✅ Dependencies installed
 
+REM Ensure correct Google GenAI package is installed (avoid deprecated package)
+python -m pip show google-generativeai >nul 2>&1
+if not errorlevel 1 (
+    echo ⚠️  Detected deprecated google-generativeai package. Removing...
+    python -m pip uninstall -y google-generativeai --quiet
+)
+
+python -m pip show google-genai >nul 2>&1
+if errorlevel 1 (
+    echo 📦 Installing google-genai (required for from google import genai)...
+    python -m pip install google-genai --quiet
+)
+
 REM Initialize configuration
 echo 🔧 Setting up configuration...
 

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,17 @@ echo "📦 Installing dependencies..."
 pip install -r requirements.txt --quiet
 echo "✅ Dependencies installed"
 
+# Ensure correct Google GenAI package is installed (avoid deprecated package)
+if python -m pip show google-generativeai > /dev/null 2>&1; then
+    echo "⚠️  Detected deprecated google-generativeai package. Removing..."
+    python -m pip uninstall -y google-generativeai --quiet || true
+fi
+
+if ! python -m pip show google-genai > /dev/null 2>&1; then
+    echo "📦 Installing google-genai (required for from google import genai)..."
+    python -m pip install google-genai --quiet
+fi
+
 # Initialize configuration
 echo "🔧 Setting up configuration..."
 


### PR DESCRIPTION
### Motivation
- Users reported `ModuleNotFoundError: No module named 'google'` during setup because the installers could leave or not install the correct SDK variant.  
- The installers should proactively remove the deprecated package variant and ensure the supported `google-genai` package is installed so the runtime import `from google import genai` works.

### Description
- Updated `install.sh` to detect and uninstall the deprecated `google-generativeai` package and to install `google-genai` if it is missing.  
- Updated `install.bat` with the same detection/uninstall and install logic for Windows users.  
- Added `artifacts/plan_install_google_genai.md` documenting the change and rationale following the repository's artifact-first workflow.

### Testing
- No automated tests were run for these installer script changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c5003a0c48330bb50e8a38ff723dc)