### PR TITLE
fix: avoid shutdown warnings for uninitialized MCP connections

### DIFF
--- a/src/mcp_client.py
+++ b/src/mcp_client.py
@@ -451,9 +451,9 @@ Input Schema:
 
         for name, connection in self.servers.items():
             try:
-                if connection.session:
+                if connection.session is not None:
                     await connection.session.__aexit__(None, None, None)
-                if hasattr(connection, "_client_cm"):
+                if connection._client_cm is not None:
                     await connection._client_cm.__aexit__(None, None, None)
                 print(f"   ✓ Disconnected from {name}")
             except Exception as e:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -395,3 +395,26 @@ class TestMCPToolWrapper:
         assert "test tool" in wrapper.__doc__.lower()
         assert "test" in wrapper.__doc__  # Server name
         assert "MCP" in wrapper.__doc__
+
+
+class TestMCPShutdown:
+    """Tests for MCP client shutdown behavior."""
+
+    @pytest.mark.asyncio
+    async def test_shutdown_skips_missing_context_managers(self):
+        """Shutdown should not warn when optional context managers are absent."""
+        from src.mcp_client import MCPClientManager, MCPServerConnection
+
+        manager = MCPClientManager()
+        config = MCPServerConfig(name="test", transport="stdio", command="echo")
+        manager.servers["test"] = MCPServerConnection(config=config)
+
+        with patch("builtins.print") as mock_print:
+            await manager.shutdown()
+
+        printed = "\n".join(
+            " ".join(str(arg) for arg in call.args) for call in mock_print.call_args_list
+        )
+        assert "Error disconnecting" not in printed
+        assert manager.servers == {}
+        assert manager._initialized is False


### PR DESCRIPTION
## What changed
- Updated `MCPClientManager.shutdown()` to only call `__aexit__` when `session` / `_client_cm` are not `None`.
- Added a regression test (`TestMCPShutdown.test_shutdown_skips_missing_context_managers`) to verify shutdown does not emit disconnect errors for uninitialized connections.

## Why
- `MCPServerConnection` always has an `_client_cm` attribute, but it may be `None` for servers that never fully connected.
- The previous `hasattr(...)` check could still try `await None.__aexit__(...)`, producing noisy warning logs during normal shutdown.
- This change keeps shutdown graceful for partially initialized servers.

## Testing
- ✅ `source .venv/bin/activate && pytest -q` (67 passed)
