### PR TITLE
fix: confine knowledge-layer workspace paths

### DIFF
--- a/artifacts/plan_vuln_workspace_confinement.md
+++ b/artifacts/plan_vuln_workspace_confinement.md
@@ -1,0 +1,6 @@
+# Plan: knowledge-layer workspace confinement fix
+
+1. Verify vulnerability still exists in `engine/antigravity_engine/skills/knowledge-layer/tools.py` by checking path resolution and pipeline calls.
+2. Implement minimal fix to constrain resolved workspace paths to the trusted project root.
+3. Add/adjust tests to cover rejecting out-of-scope workspace paths.
+4. Run targeted tests and capture output in `artifacts/logs/`.

--- a/engine/antigravity_engine/skills/knowledge-layer/tools.py
+++ b/engine/antigravity_engine/skills/knowledge-layer/tools.py
@@ -9,15 +9,36 @@ import asyncio
 import os
 from pathlib import Path
 
+from antigravity_engine.hub._utils import is_safe_path
 
-def _resolve_workspace(workspace: str | None = None) -> Path:
-    """Resolve workspace path from explicit arg, env var, or cwd."""
-    if workspace:
-        return Path(workspace).resolve()
+
+def _workspace_root() -> Path:
+    """Resolve the trusted workspace root from env var or current directory."""
     env = os.environ.get("WORKSPACE_PATH", "").strip()
     if env:
         return Path(env).resolve()
-    return Path.cwd()
+    return Path.cwd().resolve()
+
+
+def _resolve_workspace(workspace: str | None = None) -> Path:
+    """Resolve and validate workspace path from explicit arg, env var, or cwd.
+
+    Args:
+        workspace: Optional workspace path override.
+
+    Returns:
+        A canonical workspace path constrained to the trusted workspace root.
+
+    Raises:
+        ValueError: If the provided workspace escapes the trusted workspace root.
+    """
+    root = _workspace_root()
+    candidate = Path(workspace).resolve() if workspace else root
+    if not is_safe_path(root, candidate):
+        raise ValueError(
+            "workspace must be inside the current project workspace"
+        )
+    return candidate
 
 
 def refresh_filesystem(workspace: str = ".", quick: bool = False) -> str:

--- a/engine/tests/test_graph_skills.py
+++ b/engine/tests/test_graph_skills.py
@@ -84,6 +84,7 @@ def test_refresh_filesystem_reports_generated_artifacts(
     import antigravity_engine.hub.pipeline as pipeline_mod
 
     monkeypatch.setattr(pipeline_mod, "refresh_pipeline", fake_refresh_pipeline)
+    monkeypatch.setenv("WORKSPACE_PATH", str(tmp_path))
 
     result = module.refresh_filesystem(workspace=str(tmp_path), quick=True)
 
@@ -104,7 +105,27 @@ def test_ask_filesystem_delegates_to_pipeline(tmp_path: Path, monkeypatch) -> No
     import antigravity_engine.hub.pipeline as pipeline_mod
 
     monkeypatch.setattr(pipeline_mod, "ask_pipeline", fake_ask_pipeline)
+    monkeypatch.setenv("WORKSPACE_PATH", str(tmp_path))
 
     result = module.ask_filesystem("What changed?", workspace=str(tmp_path))
 
     assert result == "graph-aware answer"
+
+
+def test_knowledge_layer_rejects_workspace_outside_root(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """knowledge-layer tools should reject workspace paths outside root."""
+    module = _load_skill_tools_module("knowledge-layer")
+    outside = tmp_path.parent / "outside"
+    outside.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("WORKSPACE_PATH", str(tmp_path))
+
+    try:
+        module.refresh_filesystem(workspace=str(outside))
+    except ValueError as exc:
+        assert "workspace must be inside" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for out-of-workspace path.")


### PR DESCRIPTION
### Motivation
- A knowledge-layer skill exposed `ask_filesystem`/`refresh_filesystem` that resolved arbitrary workspace paths and invoked pipeline scans, allowing scans and writes outside the intended project root.
- The change confines resolved workspace paths to a trusted root to prevent prompt-injected tools from performing out-of-scope filesystem access while preserving in-project behavior.

### Description
- Add a trusted root resolver ` _workspace_root()` and validate candidate paths in `_resolve_workspace()` using `is_safe_path`, raising `ValueError` for out-of-root paths in `engine/antigravity_engine/skills/knowledge-layer/tools.py`.
- Keep `refresh_filesystem` and `ask_filesystem` behavior intact so they still call the same pipelines but only after path validation via the updated resolver.
- Update `engine/tests/test_graph_skills.py` to set `WORKSPACE_PATH` in tests and add `test_knowledge_layer_rejects_workspace_outside_root` to cover rejecting out-of-scope workspace overrides.
- Add a short plan artifact at `artifacts/plan_vuln_workspace_confinement.md` documenting the fix workflow.

### Testing
- Ran `pytest engine/tests/test_graph_skills.py -q` and all tests passed (4 passed).
- Ran `pytest engine/tests/test_skills_loader.py -q` and all tests passed (5 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce3ade9b008330a3e6bdde02ef6293)