### PR TITLE
fix(security): gate MCP autoconnection behind explicit runtime opt-in

### DIFF
--- a/engine/antigravity_engine/hub/ask_pipeline.py
+++ b/engine/antigravity_engine/hub/ask_pipeline.py
@@ -29,6 +29,10 @@ async def ask_pipeline(workspace: Path, question: str) -> str:
 
     Returns:
         Answer string.
+
+    Notes:
+        MCP servers are only auto-connected when both ``MCP_ENABLED=true`` and
+        ``AG_ALLOW_MCP=true`` are set in the runtime environment.
     """
     from agents import set_tracing_disabled
 
@@ -62,7 +66,12 @@ async def ask_pipeline(workspace: Path, question: str) -> str:
 
     mcp_tools: dict | None = None
     mcp_manager = None
-    if settings.MCP_ENABLED:
+    mcp_runtime_opt_in = os.environ.get("AG_ALLOW_MCP", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    if settings.MCP_ENABLED and mcp_runtime_opt_in:
         print("[…] Connecting to MCP servers...", file=sys.stderr)
         try:
             from antigravity_engine.mcp_client import MCPClientManager
@@ -78,6 +87,10 @@ async def ask_pipeline(workspace: Path, question: str) -> str:
             logger.warning("MCP initialization failed: %s", exc)
             print(f"  ⚠ MCP init failed: {exc}", file=sys.stderr)
             mcp_manager = None
+    elif settings.MCP_ENABLED:
+        logger.info(
+            "MCP is enabled in settings but AG_ALLOW_MCP is not set; skipping MCP server autoconnection"
+        )
 
     agent = build_reviewer_agent(model, workspace=workspace, mcp_tools=mcp_tools)
     try:

--- a/engine/tests/test_mcp_integration.py
+++ b/engine/tests/test_mcp_integration.py
@@ -2,7 +2,6 @@
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 
 
 def test_build_ask_swarm_without_mcp(tmp_path: Path) -> None:
@@ -95,8 +94,7 @@ def test_build_ask_swarm_empty_mcp_tools(tmp_path: Path) -> None:
     assert "MCP tools available" not in agent.instructions
 
 
-@pytest.mark.asyncio
-async def test_ask_pipeline_mcp_disabled(tmp_path: Path, monkeypatch) -> None:
+def test_ask_pipeline_mcp_disabled(tmp_path: Path, monkeypatch) -> None:
     """When MCP_ENABLED=false, no MCP connections are attempted."""
     from antigravity_engine.config import reset_settings
 
@@ -124,11 +122,57 @@ async def test_ask_pipeline_mcp_disabled(tmp_path: Path, monkeypatch) -> None:
     ):
         from antigravity_engine.hub.pipeline import ask_pipeline
 
-        result = await ask_pipeline(tmp_path, "test question")
+        import asyncio
+
+        result = asyncio.run(ask_pipeline(tmp_path, "test question"))
 
         # build_ask_swarm should be called with mcp_tools=None
         mock_build.assert_called_once()
         _, kwargs = mock_build.call_args
         assert kwargs.get("mcp_tools") is None
+
+    assert result == "test answer"
+
+
+def test_ask_pipeline_mcp_enabled_without_runtime_opt_in(tmp_path: Path, monkeypatch) -> None:
+    """MCP must not autoconnect unless AG_ALLOW_MCP is set in process env."""
+    from antigravity_engine.config import reset_settings
+
+    reset_settings()
+    monkeypatch.setenv("MCP_ENABLED", "true")
+    monkeypatch.delenv("AG_ALLOW_MCP", raising=False)
+    monkeypatch.setenv("WORKSPACE_PATH", str(tmp_path))
+
+    mock_agent = MagicMock()
+    mock_result = MagicMock()
+    mock_result.final_output = "test answer"
+
+    with patch(
+        "antigravity_engine.hub.agents.build_ask_swarm",
+        return_value=mock_agent,
+    ) as mock_build, patch(
+        "antigravity_engine.hub.pipeline._build_ask_context",
+        return_value="test context",
+    ), patch(
+        "antigravity_engine.hub.agents.create_model",
+        return_value="test-model",
+    ), patch(
+        "agents.Runner.run",
+        new_callable=AsyncMock,
+        return_value=mock_result,
+    ), patch(
+        "antigravity_engine.mcp_client.MCPClientManager.initialize",
+        new_callable=AsyncMock,
+    ) as mock_mcp_init:
+        from antigravity_engine.hub.pipeline import ask_pipeline
+
+        import asyncio
+
+        result = asyncio.run(ask_pipeline(tmp_path, "test question"))
+
+        mock_build.assert_called_once()
+        _, kwargs = mock_build.call_args
+        assert kwargs.get("mcp_tools") is None
+        mock_mcp_init.assert_not_called()
 
     assert result == "test answer"


### PR DESCRIPTION
### Motivation
- Prevent untrusted repository configuration (.env + mcp_servers.json) from causing automatic MCP stdio server connections and executing arbitrary commands when users run `ag-ask`.
- Make MCP autoconnect a deliberate runtime action instead of solely relying on repository-controlled settings.

### Description
- Require an explicit runtime opt-in by checking `AG_ALLOW_MCP` in the process environment and only auto-initializing MCP when both `MCP_ENABLED=true` (settings) and `AG_ALLOW_MCP=true` are present in the environment (`ask_pipeline`).
- Add a log/info path that notes when `MCP_ENABLED` is set but `AG_ALLOW_MCP` is not, and skip autoconnection in that case.
- Update `ask_pipeline` docstring to document the new dual-condition behavior for MCP autoconnection.
- Add integration coverage (`engine/tests/test_mcp_integration.py`) validating that MCP is not initialized when only `MCP_ENABLED` is set, and adapt the test harness to run the pipeline with `asyncio.run` for deterministic execution.

### Testing
- Ran `pytest engine/tests/test_mcp_integration.py -q` which completed successfully (`6 passed`).
- Ran `pytest engine/tests/test_hub_agents_import.py -q` which completed successfully (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce37cd6b808330a549b57f6c924b1d)