### PR TITLE
feat: add 'ag clean' command and __main__ protector

### DIFF
--- a/cli/src/ag_cli/cli.py
+++ b/cli/src/ag_cli/cli.py
@@ -277,5 +277,45 @@ def log_decision_cmd(
     console.print(f"[green]Logged decision to {target.relative_to(workspace_path)}[/green]")
 
 
+@app.command("clean")
+def clean_cmd(
+    workspace: str = typer.Option(".", "--workspace", "-w", help="Project directory."),
+    force: bool = typer.Option(False, "--force", "-f", help="Force clean without prompting."),
+) -> None:
+    """Clean agent memory and logs to restore a pristine environment."""
+    workspace_path = Path(workspace).resolve()
+
+    if not force:
+        if not typer.confirm(f"Are you sure you want to clean logs and memory in {workspace_path}?"):
+            console.print("[dim]Aborted clean.[/dim]")
+            raise typer.Exit()
+
+    cleaned_count = 0
+
+    # Directories to clean
+    dirs_to_clean = [
+        workspace_path / "artifacts" / "logs",
+        workspace_path / ".antigravity" / "memory",
+        workspace_path / "memory", # legacy
+    ]
+
+    for d in dirs_to_clean:
+        if d.exists() and d.is_dir():
+            for item in d.iterdir():
+                if item.name == ".gitkeep":
+                    continue
+                try:
+                    if item.is_file():
+                        item.unlink(missing_ok=True)
+                        cleaned_count += 1
+                    elif item.is_dir():
+                        shutil.rmtree(item, ignore_errors=True)
+                        cleaned_count += 1
+                except Exception:
+                    pass
+
+    console.print(f"[green]✔ Cleaned {cleaned_count} temporary files/directories.[/green]")
+
+
 if __name__ == "__main__":
     app()

--- a/engine/antigravity_engine/__main__.py
+++ b/engine/antigravity_engine/__main__.py
@@ -1,3 +1,4 @@
 from antigravity_engine._cli_entry import engine_main
 
-engine_main()
+if __name__ == "__main__":
+    engine_main()


### PR DESCRIPTION
Summary
This PR introduces a new CLI command ag clean and adds standard Python best practices to the engine entry point.

Changes
1. Added ag clean command: 
   • Allows users to quickly remove temporary logs and memory files from artifacts/logs/ and .antigravity/memory/.
   • Includes a safety confirmation prompt (overridable with -f or --force).
   • Specifically preserves .gitkeep files to maintain directory structure.
2. Added main protector:
   • Added if name == "main": to engine/antigravity_engine/main.py to prevent accidental execution upon import.

此拉取请求引入了一个新的命令行界面（CLI）命令 “ag clean”，给入口文件加了标准的 Python 安全启动写法（防止被误执行）。
变更内容
添加 “ag clean” 命令：
允许用户快速删除 “artifacts/logs/” 和 “.antigravity/memory/” 中的临时日志和内存文件。
包含一个安全确认提示（可使用 “-f” 或 “--force” 覆盖）。
特别保留 “.gitkeep” 文件以维持目录结构。
添加主保护程序：
在 “engine/antigravity_engine/main.py” 中添加 “if name == "main":”，以防止导入时意外执行。
