### PR TITLE
Export refresh-time graph JSONL and add query_graph fallback to knowledge_graph.json

### DIFF
--- a/artifacts/plan_graph_refresh_export.md
+++ b/artifacts/plan_graph_refresh_export.md
@@ -1,0 +1,7 @@
+# Plan: graph refresh export + retrieval fallback
+
+1. Inspect refresh pipeline and graph retrieval skill behavior.
+2. Add normalized graph JSONL export in refresh stage after knowledge_graph.json write.
+3. Add fallback in graph retrieval skill to load knowledge_graph.json when JSONL is absent.
+4. Add tests validating fallback and refresh-only graph query behavior.
+5. Run focused tests and capture log artifact.

--- a/engine/antigravity_engine/hub/refresh_pipeline.py
+++ b/engine/antigravity_engine/hub/refresh_pipeline.py
@@ -12,6 +12,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -146,6 +147,7 @@ async def refresh_pipeline(workspace: Path, quick: bool = False) -> None:
             json.dumps(graph, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
+        _export_normalized_graph_store(ag_dir, graph)
         (ag_dir / "knowledge_graph.md").write_text(
             render_knowledge_graph_markdown(graph),
             encoding="utf-8",
@@ -399,6 +401,67 @@ def _format_scan_report(report) -> str:
         lines.append(f"\n--- Git activity ---\n{git_summary}")
 
     return "\n".join(lines)
+
+
+def _export_normalized_graph_store(ag_dir: Path, graph: dict[str, Any]) -> None:
+    """Export knowledge graph into normalized JSONL graph store files.
+
+    Args:
+        ag_dir: The ``.antigravity`` directory path.
+        graph: The in-memory knowledge graph payload.
+    """
+    graph_dir = ag_dir / "graph"
+    graph_dir.mkdir(parents=True, exist_ok=True)
+
+    nodes = graph.get("nodes", [])
+    edges = graph.get("edges", [])
+    if not isinstance(nodes, list):
+        nodes = []
+    if not isinstance(edges, list):
+        edges = []
+
+    retrieval_id = str(graph.get("created_at_utc", "")) or "refresh-knowledge-graph"
+    tool_name = "refresh_pipeline"
+
+    nodes_lines: list[str] = []
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        nodes_lines.append(
+            json.dumps(
+                {
+                    "schema": "antigravity-graph-node-v1",
+                    "retrieval_id": retrieval_id,
+                    "tool_name": tool_name,
+                    "node": node,
+                },
+                ensure_ascii=False,
+            )
+        )
+    (graph_dir / "nodes.jsonl").write_text(
+        ("\n".join(nodes_lines) + "\n") if nodes_lines else "",
+        encoding="utf-8",
+    )
+
+    edges_lines: list[str] = []
+    for edge in edges:
+        if not isinstance(edge, dict):
+            continue
+        edges_lines.append(
+            json.dumps(
+                {
+                    "schema": "antigravity-graph-edge-v1",
+                    "retrieval_id": retrieval_id,
+                    "tool_name": tool_name,
+                    "edge": edge,
+                },
+                ensure_ascii=False,
+            )
+        )
+    (graph_dir / "edges.jsonl").write_text(
+        ("\n".join(edges_lines) + "\n") if edges_lines else "",
+        encoding="utf-8",
+    )
 
 
 def _get_head_sha(workspace: Path) -> str | None:

--- a/engine/antigravity_engine/skills/graph-retrieval/tools.py
+++ b/engine/antigravity_engine/skills/graph-retrieval/tools.py
@@ -72,6 +72,63 @@ def _edge_text(edge: dict[str, Any]) -> str:
     )
 
 
+def _read_knowledge_graph_rows(workspace: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Read fallback graph rows from ``knowledge_graph.json``.
+
+    Args:
+        workspace: Workspace root path.
+
+    Returns:
+        Tuple of ``(nodes_rows, edges_rows)`` in normalized JSONL-like format.
+    """
+    knowledge_graph_path = workspace / ".antigravity" / "knowledge_graph.json"
+    if not knowledge_graph_path.exists() or not knowledge_graph_path.is_file():
+        return [], []
+
+    try:
+        graph = json.loads(knowledge_graph_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return [], []
+
+    if not isinstance(graph, dict):
+        return [], []
+
+    retrieval_id = str(graph.get("created_at_utc", "")) or "refresh-knowledge-graph"
+    tool_name = "refresh_pipeline"
+
+    nodes_rows: list[dict[str, Any]] = []
+    raw_nodes = graph.get("nodes", [])
+    if isinstance(raw_nodes, list):
+        for node in raw_nodes:
+            if not isinstance(node, dict):
+                continue
+            nodes_rows.append(
+                {
+                    "schema": "antigravity-graph-node-v1",
+                    "retrieval_id": retrieval_id,
+                    "tool_name": tool_name,
+                    "node": node,
+                }
+            )
+
+    edges_rows: list[dict[str, Any]] = []
+    raw_edges = graph.get("edges", [])
+    if isinstance(raw_edges, list):
+        for edge in raw_edges:
+            if not isinstance(edge, dict):
+                continue
+            edges_rows.append(
+                {
+                    "schema": "antigravity-graph-edge-v1",
+                    "retrieval_id": retrieval_id,
+                    "tool_name": tool_name,
+                    "edge": edge,
+                }
+            )
+
+    return nodes_rows, edges_rows
+
+
 def query_graph(query: str, max_hops: int = 2, workspace: str = ".") -> dict[str, Any]:
     """Retrieve a relevant semantic subgraph for a user query.
 
@@ -87,6 +144,8 @@ def query_graph(query: str, max_hops: int = 2, workspace: str = ".") -> dict[str
     max_rows = max(100, max_rows)
     nodes_rows = _read_jsonl(graph_dir / "nodes.jsonl", max_rows=max_rows)
     edges_rows = _read_jsonl(graph_dir / "edges.jsonl", max_rows=max_rows)
+    if not nodes_rows and not edges_rows:
+        nodes_rows, edges_rows = _read_knowledge_graph_rows(ws)
 
     if not query.strip():
         return {
@@ -99,7 +158,7 @@ def query_graph(query: str, max_hops: int = 2, workspace: str = ".") -> dict[str
 
     if not nodes_rows and not edges_rows:
         return {
-            "summary": "No graph store found. Run retrieval tools first.",
+            "summary": "No graph store found. Run refresh or retrieval tools first.",
             "triples": [],
             "evidence": [],
             "nodes": [],

--- a/engine/tests/test_graph_skills.py
+++ b/engine/tests/test_graph_skills.py
@@ -1,6 +1,7 @@
 """Tests for graph-retrieval and knowledge-layer skills."""
 
 from importlib.util import module_from_spec, spec_from_file_location
+import json
 from pathlib import Path
 from types import ModuleType
 
@@ -60,6 +61,38 @@ def test_query_graph_returns_relevant_subgraph(tmp_path: Path) -> None:
     assert result["triples"]
     assert ["login", "defined_in", "auth module"] in result["triples"]
     assert {"retrieval_id": "r1", "tool_name": "search_code"} in result["evidence"]
+
+
+def test_query_graph_after_refresh_without_retrieval_graph_jsonl(tmp_path: Path) -> None:
+    """query_graph should fallback to knowledge_graph.json when JSONL files are missing."""
+    ag_dir = tmp_path / ".antigravity"
+    ag_dir.mkdir(parents=True)
+    (ag_dir / "knowledge_graph.json").write_text(
+        json.dumps(
+            {
+                "schema": "antigravity-knowledge-graph-v2",
+                "created_at_utc": "2026-04-09T00:00:00+00:00",
+                "workspace": str(tmp_path.resolve()),
+                "nodes": [
+                    {"id": "function:query_graph", "type": "function", "label": "query_graph"},
+                    {"id": "module:graph_retrieval", "type": "module", "label": "graph retrieval"},
+                ],
+                "edges": [
+                    {"from": "function:query_graph", "to": "module:graph_retrieval", "type": "defined_in"},
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    module = _load_skill_tools_module("graph-retrieval")
+    result = module.query_graph("query_graph module", workspace=str(tmp_path))
+
+    assert result["triples"]
+    assert result["evidence"]
+    assert any(t[1] == "defined_in" for t in result["triples"])
 
 
 def test_refresh_filesystem_reports_generated_artifacts(


### PR DESCRIPTION
### Motivation
- Ensure graph-based retrieval can return usable triples/evidence immediately after a refresh without requiring a prior retrieval run.
- Persist a normalized, retrieval-friendly graph store during refresh so skills can consume a stable JSONL representation.
- Improve robustness of `query_graph` by falling back to the canonical `knowledge_graph.json` when the JSONL store is absent.

### Description
- Add ` _export_normalized_graph_store` to `engine/antigravity_engine/hub/refresh_pipeline.py` and call it right after writing `knowledge_graph.json` to emit `.antigravity/graph/nodes.jsonl` and `.antigravity/graph/edges.jsonl`.
- Add `_read_knowledge_graph_rows` to `engine/antigravity_engine/skills/graph-retrieval/tools.py` and wire it into `query_graph` so it loads and normalizes `knowledge_graph.json` when `nodes.jsonl`/`edges.jsonl` are missing.
- Keep the JSONL-first behavior in `query_graph` and adjust the no-data summary to recommend running refresh or retrieval tools.
- Add a test `test_query_graph_after_refresh_without_retrieval_graph_jsonl` to `engine/tests/test_graph_skills.py` and a lightweight plan artifact at `artifacts/plan_graph_refresh_export.md`.

### Testing
- Ran `pytest engine/tests/test_graph_skills.py -q`.
- Result: `5 passed` (all tests in that file succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d72bf1e918833084644faf98b48e82)