### PR TITLE
Add trusted workspace root validation to graph-retrieval skill

### DIFF
--- a/engine/antigravity_engine/skills/graph-retrieval/tools.py
+++ b/engine/antigravity_engine/skills/graph-retrieval/tools.py
@@ -13,11 +13,36 @@ from collections import defaultdict, deque
 from pathlib import Path
 from typing import Any
 
+from antigravity_engine.hub._utils import is_safe_path
+
+
+def _workspace_root() -> Path:
+    """Resolve the trusted workspace root from env var or current directory."""
+    env = os.environ.get("WORKSPACE_PATH", "").strip()
+    if env:
+        return Path(env).resolve()
+    return Path.cwd().resolve()
+
 
 def _resolve_workspace(workspace: str | None = None) -> Path:
-    if workspace:
-        return Path(workspace).resolve()
-    return Path.cwd().resolve()
+    """Resolve and validate workspace path from explicit arg, env var, or cwd.
+
+    Args:
+        workspace: Optional workspace path override.
+
+    Returns:
+        A canonical workspace path constrained to the trusted workspace root.
+
+    Raises:
+        ValueError: If the provided workspace escapes the trusted workspace root.
+    """
+    root = _workspace_root()
+    candidate = Path(workspace).resolve() if workspace else root
+    if not is_safe_path(root, candidate):
+        raise ValueError(
+            "workspace must be inside the current project workspace"
+        )
+    return candidate
 
 
 def _read_jsonl(path: Path, max_rows: int | None = None) -> list[dict[str, Any]]:

--- a/engine/tests/test_graph_skills.py
+++ b/engine/tests/test_graph_skills.py
@@ -26,7 +26,10 @@ def _load_skill_tools_module(skill_name: str) -> ModuleType:
     return module
 
 
-def test_query_graph_returns_relevant_subgraph(tmp_path: Path) -> None:
+def test_query_graph_returns_relevant_subgraph(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
     """query_graph should return matching triples and replayable evidence."""
     graph_dir = tmp_path / ".antigravity" / "graph"
     graph_dir.mkdir(parents=True)
@@ -52,6 +55,8 @@ def test_query_graph_returns_relevant_subgraph(tmp_path: Path) -> None:
         + "\n",
         encoding="utf-8",
     )
+
+    monkeypatch.setenv("WORKSPACE_PATH", str(tmp_path))
 
     module = _load_skill_tools_module("graph-retrieval")
     result = module.query_graph("login auth", workspace=str(tmp_path))
@@ -111,6 +116,26 @@ def test_ask_filesystem_delegates_to_pipeline(tmp_path: Path, monkeypatch) -> No
 
     assert result == "graph-aware answer"
 
+
+
+
+def test_graph_retrieval_rejects_workspace_outside_root(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """graph-retrieval tools should reject workspace paths outside root."""
+    module = _load_skill_tools_module("graph-retrieval")
+    outside = tmp_path.parent / "outside"
+    outside.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("WORKSPACE_PATH", str(tmp_path))
+
+    try:
+        module.query_graph("login", workspace=str(outside))
+    except ValueError as exc:
+        assert "workspace must be inside" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for out-of-workspace path.")
 
 def test_knowledge_layer_rejects_workspace_outside_root(
     tmp_path: Path,


### PR DESCRIPTION
### Motivation
- Align `graph-retrieval` workspace resolution with the trusted-root behavior used by `knowledge-layer` to prevent tools from operating on workspaces outside the intended project root. 

### Description
- Add `_workspace_root()` that prefers `WORKSPACE_PATH` and falls back to `Path.cwd()` in `engine/antigravity_engine/skills/graph-retrieval/tools.py`.
- Import and use `antigravity_engine.hub._utils.is_safe_path` and update `_resolve_workspace()` to validate candidate workspaces and raise `ValueError` when a workspace escapes the trusted root.
- Update `engine/tests/test_graph_skills.py` to set `WORKSPACE_PATH` in the existing `test_query_graph_returns_relevant_subgraph` so it remains valid under the new trust boundary.
- Add `test_graph_retrieval_rejects_workspace_outside_root` to verify that `query_graph` rejects out-of-root `workspace` paths consistent with the knowledge-layer behavior.

### Testing
- Ran `pytest engine/tests/test_graph_skills.py -q`, which executed the modified and new tests and completed with `5 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d72c17630883309297790fac1d3c37)