### PR TITLE
fix(hub): sync GOOGLE_API_KEY to os.environ for litellm (Windows .env fix)

### DIFF
--- a/engine/antigravity_engine/hub/agents.py
+++ b/engine/antigravity_engine/hub/agents.py
@@ -45,6 +45,7 @@ def create_model(settings: "Settings") -> str:
     import os
 
     if settings.GOOGLE_API_KEY:
+        os.environ["GOOGLE_API_KEY"] = settings.GOOGLE_API_KEY
         return f"litellm/gemini/{settings.GEMINI_MODEL_NAME}"
 
     # Custom endpoint (NVIDIA, Ollama, etc.) — route through litellm.

--- a/engine/tests/test_create_model.py
+++ b/engine/tests/test_create_model.py
@@ -1,4 +1,5 @@
 """Tests for hub.agents.create_model() LLM backend resolution."""
+import os
 import pytest
 from unittest.mock import patch
 
@@ -30,6 +31,7 @@ def test_google_key_returns_litellm_gemini():
     result = create_model(settings)
     assert result.startswith("litellm/gemini/")
     assert "gemini-2.0-flash-exp" in result
+    assert os.environ.get("GOOGLE_API_KEY") == "goog-key-123"
 
 
 def test_openai_key_only_returns_model_name():


### PR DESCRIPTION
## Summary
- Sync `settings.GOOGLE_API_KEY` to `os.environ["GOOGLE_API_KEY"]` in `create_model()` so litellm can read it
- Fixes Windows users who only configure the API key in `.env` — pydantic-settings loads it into the model but not into `os.environ`
- Consistent with the existing `OPENAI_API_BASE`/`OPENAI_API_KEY` sync pattern

Closes #47

## Test plan
- [x] `test_google_key_returns_litellm_gemini` updated to verify env var is synced
- [x] All 5 `test_create_model` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Google API key is now correctly configured in the environment when using Google models.

## Tests
* Added test coverage to verify Google API key environment configuration is properly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->