### PR TITLE
[codex] docs: sync README philosophy copy across languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Language: **English** | [中文](README_CN.md) | [Español](README_ES.md)
 
 The engine is the core: `ag-refresh` deploys a multi-agent cluster that autonomously reads your code — each module gets its own Agent that generates a knowledge doc. `ag-ask` routes questions to the right Agent, grounded in real code with file paths and line numbers.
 
+**Instead of handing Claude Code / Codex a repo-wide `grep` and making it hunt on its own, give it a ChatGPT for your repository.**
+
 **Tested on [OpenClaw](https://github.com/openclaw/openclaw) (12K files, 348K stars) with MiniMax2.7 — module Q&A scored 10/10, 111 modules self-learned in 43 minutes.** [See full eval below.](#real-world-eval-minimax27-on-openclaw-12k-files-348k-stars)
 
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -42,6 +42,8 @@
 
 引擎是核心：`ag-refresh` 部署多智能体集群自主阅读代码——每个模块分配专属 Agent 生成知识文档。`ag-ask` 将问题路由到对应 Agent，答案有据可查，带文件路径和行号。
 
+**与其给 Claude Code / Codex 一个仓库 `grep` 让它自己找，不如给它一个仓库版本的 ChatGPT。**
+
 **已在 [OpenClaw](https://github.com/openclaw/openclaw)（12K 文件，34.8 万 Star）上用 MiniMax2.7 测试——模块问答 10/10，111 个模块 43 分钟自学完成。** [查看完整评估](#大规模评估minimax27--openclaw12k-文件348-万-star)
 
 ```

--- a/README_ES.md
+++ b/README_ES.md
@@ -42,6 +42,8 @@ Idioma: [English](README.md) | [中文](README_CN.md) | **Español**
 
 El motor es el núcleo: `ag-refresh` despliega un clúster multi-agente que lee tu código autónomamente — cada módulo obtiene su propio Agent que genera documentación de conocimiento. `ag-ask` enruta preguntas al Agent correcto, con respuestas basadas en código real con rutas de archivo y números de línea.
 
+**En vez de darle a Claude Code / Codex un `grep` del repositorio para que busque por su cuenta, dale un ChatGPT para tu repositorio.**
+
 **Evaluado en [OpenClaw](https://github.com/openclaw/openclaw) (12K archivos, 348K stars) con MiniMax2.7 — Q&A por módulo 10/10, 111 módulos auto-aprendidos en 43 minutos.** [Ver evaluación completa.](#eval-a-gran-escala-minimax27-en-openclaw-12k-archivos-348k-stars)
 
 ```


### PR DESCRIPTION
## What changed
- added the new philosophy line to the English, Chinese, and Spanish root README files
- kept the insertion point aligned across languages in the core "Why Antigravity" section

## Why
- this sharpens the product positioning around repository-aware Q&A versus repo-wide file hunting
- it makes the cross-language README messaging consistent

## User impact
- readers in all three supported README languages now see the same core framing
- no code paths or runtime behavior changed

## Validation
- docs-only change
- verified the staged diff only touched `README.md`, `README_CN.md`, and `README_ES.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README files (English, Chinese, and Spanish versions) with enhanced guidance on recommended repository search workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->