### PR TITLE
fix: add upper-bound version pins to engine dependencies

### DIFF
--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -7,9 +7,9 @@ dependencies = [
     "pydantic>=2.0,<3",
     "pydantic-settings>=2.0,<3",
     "python-dotenv>=1.0,<2",
-    "requests>=2.28,<3",
+    "requests>=2.33.0,<3",
     "mcp[cli]>=1.0.0,<2",
-    "openai-agents[litellm]>=0.0.3,<1",
+    "openai-agents[litellm]>=0.12,<0.15",
 ]
 
 [project.scripts]

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -4,12 +4,12 @@ version = "0.2.0"
 description = "Dynamic multi-agent Knowledge Hub and MCP server"
 requires-python = ">=3.10"
 dependencies = [
-    "pydantic",
-    "pydantic-settings",
-    "python-dotenv",
-    "requests",
-    "mcp[cli]>=1.0.0",
-    "openai-agents[litellm]",
+    "pydantic>=2.0,<3",
+    "pydantic-settings>=2.0,<3",
+    "python-dotenv>=1.0,<2",
+    "requests>=2.28,<3",
+    "mcp[cli]>=1.0.0,<2",
+    "openai-agents[litellm]>=0.0.3,<1",
 ]
 
 [project.scripts]


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## What and Why

`engine/pyproject.toml` declares all five runtime dependencies without upper-bound version constraints. `mcp[cli]` has a lower bound (`>=1.0.0`) but no upper bound; the others have no bounds at all. This means `pip install` will always resolve the absolute latest release, including future major versions that may introduce breaking API changes.

The risk is silent: a maintainer installs on a clean machine, gets pydantic v3 or requests v3, and hits import errors or behavioural differences that aren't caught by the current test suite.

## Fix

Added compatible upper-bound pins for each dependency:

| Before | After |
|--------|-------|
| `pydantic` | `pydantic>=2.0,<3` |
| `pydantic-settings` | `pydantic-settings>=2.0,<3` |
| `python-dotenv` | `python-dotenv>=1.0,<2` |
| `requests` | `requests>=2.28,<3` |
| `mcp[cli]>=1.0.0` | `mcp[cli]>=1.0.0,<2` |
| `openai-agents[litellm]` | `openai-agents[litellm]>=0.0.3,<1` |

These ranges allow patch and minor updates within the current major series, which is the standard Python packaging convention for libraries that follow SemVer. When you intentionally upgrade to a new major (e.g. pydantic v3), bump the upper bound at the same time as updating the code.

<!-- nlpm-metadata-begin
{"version":1,"findings":[]}
nlpm-metadata-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened core dependency version ranges to improve stability and compatibility, specifically constraining releases for pydantic, pydantic-settings, python-dotenv, requests, mcp, and openai-agents to known compatible major/minor ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->