### PR TITLE
feat: 添加重试机制、增量刷新、模型推理强度及流式响应支持

### DIFF
--- a/cli/src/ag_cli/cli.py
+++ b/cli/src/ag_cli/cli.py
@@ -244,12 +244,15 @@ def ask_cmd(
 def refresh_cmd(
     workspace: str = typer.Option(".", "--workspace", "-w", help="Project directory."),
     quick: bool = typer.Option(False, "--quick", help="Only scan changed files."),
+    failed_only: bool = typer.Option(False, "--failed-only", help="Only re-run modules that failed in the previous refresh."),
 ) -> None:
     """Refresh project context in .antigravity/ (requires LLM)."""
     workspace_path = Path(workspace).resolve()
     args: list[str] = ["refresh"]
     if quick:
         args.append("--quick")
+    if failed_only:
+        args.append("--failed-only")
     code = _run_hub(workspace_path, *args)
     raise typer.Exit(code=code)
 

--- a/engine/.env.example
+++ b/engine/.env.example
@@ -17,6 +17,19 @@
 # token streaming via litellm. Default is "false".
 # STREAM_ENABLED=false
 
+# -------------------------------------------------------------------
+# Reasoning effort (optional)
+# Forwarded to ModelSettings.extra_body for reasoning-capable models.
+# Common values: low, medium, high. Leave unset to disable.
+# AG_REASONING_EFFORT=
+
+# -------------------------------------------------------------------
+# Refresh retry policy (optional)
+# Number of retries on transient errors (timeouts, rate limits, 5xx).
+# AG_REFRESH_RETRY_COUNT=3
+# Initial backoff delay in seconds (doubles each attempt).
+# AG_REFRESH_RETRY_DELAY=1.0
+
 # --------------------------------------------------------------------
 # Sandbox Configuration (optional)
 # These settings control how code execution is sandboxed.

--- a/engine/.env.example
+++ b/engine/.env.example
@@ -11,6 +11,12 @@
 # Optional: Model Configuration
 # MODEL_NAME=gemini-2.5-flash
 
+# -------------------------------------------------------------------
+# LiteLLM Stream Configuration (optional)
+# Enable streaming for LLM responses. Set to "true" for real-time
+# token streaming via litellm. Default is "false".
+# STREAM_ENABLED=false
+
 # --------------------------------------------------------------------
 # Sandbox Configuration (optional)
 # These settings control how code execution is sandboxed.

--- a/engine/antigravity_engine/_cli_entry.py
+++ b/engine/antigravity_engine/_cli_entry.py
@@ -83,7 +83,13 @@ def refresh_main(argv: Sequence[str] | None = None) -> None:
         import asyncio
         from antigravity_engine.hub.pipeline import refresh_pipeline
 
-        status = asyncio.run(refresh_pipeline(workspace, args.quick, args.failed_only))
+        status = asyncio.run(
+            refresh_pipeline(
+                workspace=workspace,
+                quick=args.quick,
+                failed_only=args.failed_only,
+            )
+        )
         if getattr(status, "exit_code", 0) != 0:
             sys.exit(int(status.exit_code))
     except ValueError as exc:

--- a/engine/antigravity_engine/_cli_entry.py
+++ b/engine/antigravity_engine/_cli_entry.py
@@ -73,6 +73,7 @@ def refresh_main(argv: Sequence[str] | None = None) -> None:
     )
     parser.add_argument("--workspace", default=".", help="Project root (default: cwd)")
     parser.add_argument("--quick", action="store_true", help="Only scan changed files")
+    parser.add_argument("--failed-only", action="store_true", help="Only re-run modules that failed in the previous refresh")
     args = _parse_args(parser, argv)
 
     workspace = Path(args.workspace).resolve()
@@ -82,7 +83,7 @@ def refresh_main(argv: Sequence[str] | None = None) -> None:
         import asyncio
         from antigravity_engine.hub.pipeline import refresh_pipeline
 
-        status = asyncio.run(refresh_pipeline(workspace, args.quick))
+        status = asyncio.run(refresh_pipeline(workspace, args.quick, args.failed_only))
         if getattr(status, "exit_code", 0) != 0:
             sys.exit(int(status.exit_code))
     except ValueError as exc:

--- a/engine/antigravity_engine/config.py
+++ b/engine/antigravity_engine/config.py
@@ -36,6 +36,12 @@ class Settings(BaseSettings):
 
     # Agent Configuration
     AGENT_NAME: str = "AntigravityAgent"
+    # Stream Configuration
+    STREAM_ENABLED: bool = Field(
+        default=False,
+        description="Enable streaming for LLM responses via litellm. "
+        "Set to true for real-time token streaming.",
+    )
     DEBUG_MODE: bool = False
     PROJECT_ROOT: str = Field(
         default_factory=lambda: os.environ.get(

--- a/engine/antigravity_engine/hub/agents.py
+++ b/engine/antigravity_engine/hub/agents.py
@@ -633,6 +633,7 @@ Rules:
 def build_refresh_module_swarm_v2(
     model: str,
     workspace: Path,
+    modules_filter: list[str] | None = None,
 ) -> list:
     """Build RefreshModuleAgents using smart functional grouping.
 
@@ -646,6 +647,8 @@ def build_refresh_module_swarm_v2(
     Args:
         model: Model identifier string.
         workspace: Project root directory.
+        modules_filter: Optional list of module names to process.
+            When provided, only these modules are included.
 
     Returns:
         List of ``(module_name, group_entries)`` tuples where each
@@ -661,6 +664,8 @@ def build_refresh_module_swarm_v2(
     )
 
     modules = detect_modules(workspace)
+    if modules_filter is not None:
+        modules = [m for m in modules if m in modules_filter]
     result: list = []
 
     for mod in modules:

--- a/engine/antigravity_engine/hub/agents.py
+++ b/engine/antigravity_engine/hub/agents.py
@@ -77,6 +77,21 @@ def _import_agent():
         ) from None
 
 
+def _get_reasoning_effort() -> str | None:
+    """Get reasoning_effort from AG_REASONING_EFFORT env var.
+
+    Passes through any value directly to the OpenAI API.
+    Common values: low, medium, high (for o1/o3 models)
+    Returns None if env var is not set.
+    """
+    import os
+
+    effort = os.environ.get("AG_REASONING_EFFORT", "").strip()
+    if effort:
+        return effort
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Refresh Swarm — 3 agents: ScanAnalyst → ArchitectureReviewer → ConventionWriter
 # ---------------------------------------------------------------------------
@@ -149,6 +164,7 @@ def build_refresh_swarm(model: str):
         name="ConventionWriter",
         instructions=_CONVENTION_WRITER_INSTRUCTIONS,
         model=model,
+        reasoning_effort=_get_reasoning_effort(),
     )
 
     architecture_reviewer = Agent(
@@ -156,6 +172,7 @@ def build_refresh_swarm(model: str):
         instructions=_ARCHITECTURE_REVIEWER_INSTRUCTIONS,
         model=model,
         handoffs=[convention_writer],
+        reasoning_effort=_get_reasoning_effort(),
     )
 
     scan_analyst = Agent(
@@ -163,6 +180,7 @@ def build_refresh_swarm(model: str):
         instructions=_SCAN_ANALYST_INSTRUCTIONS,
         model=model,
         handoffs=[architecture_reviewer],
+        reasoning_effort=_get_reasoning_effort(),
     )
 
     return scan_analyst
@@ -374,6 +392,7 @@ def build_map_agent(model: str):
         name="MapAgent",
         instructions=_MAP_AGENT_INSTRUCTIONS,
         model=model,
+        reasoning_effort=_get_reasoning_effort(),
     )
 
 
@@ -595,6 +614,7 @@ def build_refresh_module_swarm(
             instructions=instructions,
             model=model,
             tools=_wrap_tools(all_tools),
+            reasoning_effort=_get_reasoning_effort(),
         )
         agents_list.append((mod, agent))
 
@@ -694,6 +714,7 @@ def build_refresh_module_swarm_v2(
                 name=f"RefreshModule_{mod}_sub{i}_{group.name}",
                 instructions=instructions,
                 model=model,
+                reasoning_effort=_get_reasoning_effort(),
             )
             group_entries.append((group.name, group, agent))
 
@@ -732,6 +753,7 @@ def build_refresh_git_agent(model: str, workspace: Path):
         instructions=instructions,
         model=model,
         tools=_wrap_tools(all_tools),
+        reasoning_effort=_get_reasoning_effort(),
     )
 
 
@@ -772,6 +794,7 @@ def build_ask_swarm(
                 "the provided context.  Be concise and cite file paths."
             ),
             model=model,
+            reasoning_effort=_get_reasoning_effort(),
         )
 
     from antigravity_engine.hub.ask_tools import (
@@ -818,6 +841,7 @@ def build_ask_swarm(
             ),
             model=model,
             tools=wrapped + wrapped_mcp,
+            reasoning_effort=_get_reasoning_effort(),
         )
         workers.append(agent)
 
@@ -836,6 +860,7 @@ def build_ask_swarm(
         instructions=_GIT_AGENT_INSTRUCTIONS.format(knowledge=git_knowledge),
         model=model,
         tools=_wrap_tools(git_all_tools) + wrapped_mcp,
+        reasoning_effort=_get_reasoning_effort(),
     )
     workers.append(git_agent)
 
@@ -851,6 +876,7 @@ def build_ask_swarm(
         ),
         model=model,
         tools=_wrap_tools(full_tools) + wrapped_mcp,
+        reasoning_effort=_get_reasoning_effort(),
     )
     workers.append(full_worker)
 
@@ -885,6 +911,7 @@ def build_ask_swarm(
         instructions=router_instructions,
         model=model,
         handoffs=workers,
+        reasoning_effort=_get_reasoning_effort(),
     )
 
     # Star topology: workers hand off back to Router only.

--- a/engine/antigravity_engine/hub/agents.py
+++ b/engine/antigravity_engine/hub/agents.py
@@ -77,18 +77,20 @@ def _import_agent():
         ) from None
 
 
-def _get_reasoning_effort() -> dict:
-    """Get reasoning_effort kwargs from AG_REASONING_EFFORT env var.
+def _get_model_settings() -> dict:
+    """Get Agent model settings from AG_REASONING_EFFORT env var.
 
-    Passes through any value directly to the OpenAI API.
+    ``extra_body`` is the SDK escape hatch for request body fields that are
+    not first-class ``Agent`` constructor arguments.
     Common values: low, medium, high (for o1/o3 models)
     Returns empty dict if env var is not set (for SDK compatibility).
     """
     import os
+    from agents import ModelSettings
 
     effort = os.environ.get("AG_REASONING_EFFORT", "").strip()
     if effort:
-        return {"reasoning_effort": effort}
+        return {"model_settings": ModelSettings(extra_body={"reasoning_effort": effort})}
     return {}
 
 
@@ -176,7 +178,7 @@ def build_refresh_swarm(model: str):
         name="ConventionWriter",
         instructions=_CONVENTION_WRITER_INSTRUCTIONS,
         model=model,
-        **_get_reasoning_effort(),
+        **_get_model_settings(),
     )
 
     architecture_reviewer = Agent(
@@ -184,7 +186,7 @@ def build_refresh_swarm(model: str):
         instructions=_ARCHITECTURE_REVIEWER_INSTRUCTIONS,
         model=model,
         handoffs=[convention_writer],
-        **_get_reasoning_effort(),
+        **_get_model_settings(),
     )
 
     scan_analyst = Agent(
@@ -192,7 +194,7 @@ def build_refresh_swarm(model: str):
         instructions=_SCAN_ANALYST_INSTRUCTIONS,
         model=model,
         handoffs=[architecture_reviewer],
-        **_get_reasoning_effort(),
+        **_get_model_settings(),
     )
 
     return scan_analyst
@@ -404,7 +406,7 @@ def build_map_agent(model: str):
         name="MapAgent",
         instructions=_MAP_AGENT_INSTRUCTIONS,
         model=model,
-        **_get_reasoning_effort(),
+        **_get_model_settings(),
     )
 
 
@@ -626,7 +628,7 @@ def build_refresh_module_swarm(
             instructions=instructions,
             model=model,
             tools=_wrap_tools(all_tools),
-            **_get_reasoning_effort(),
+            **_get_model_settings(),
         )
         agents_list.append((mod, agent))
 
@@ -726,7 +728,7 @@ def build_refresh_module_swarm_v2(
                 name=f"RefreshModule_{mod}_sub{i}_{group.name}",
                 instructions=instructions,
                 model=model,
-                **_get_reasoning_effort(),
+                **_get_model_settings(),
             )
             group_entries.append((group.name, group, agent))
 
@@ -765,7 +767,7 @@ def build_refresh_git_agent(model: str, workspace: Path):
         instructions=instructions,
         model=model,
         tools=_wrap_tools(all_tools),
-        **_get_reasoning_effort(),
+        **_get_model_settings(),
     )
 
 
@@ -806,7 +808,7 @@ def build_ask_swarm(
                 "the provided context.  Be concise and cite file paths."
             ),
             model=model,
-            **_get_reasoning_effort(),
+            **_get_model_settings(),
         )
 
     from antigravity_engine.hub.ask_tools import (
@@ -853,7 +855,7 @@ def build_ask_swarm(
             ),
             model=model,
             tools=wrapped + wrapped_mcp,
-            **_get_reasoning_effort(),
+            **_get_model_settings(),
         )
         workers.append(agent)
 
@@ -872,7 +874,7 @@ def build_ask_swarm(
         instructions=_GIT_AGENT_INSTRUCTIONS.format(knowledge=git_knowledge),
         model=model,
         tools=_wrap_tools(git_all_tools) + wrapped_mcp,
-        **_get_reasoning_effort(),
+        **_get_model_settings(),
     )
     workers.append(git_agent)
 
@@ -888,7 +890,7 @@ def build_ask_swarm(
         ),
         model=model,
         tools=_wrap_tools(full_tools) + wrapped_mcp,
-        **_get_reasoning_effort(),
+        **_get_model_settings(),
     )
     workers.append(full_worker)
 
@@ -923,7 +925,7 @@ def build_ask_swarm(
         instructions=router_instructions,
         model=model,
         handoffs=workers,
-        **_get_reasoning_effort(),
+        **_get_model_settings(),
     )
 
     # Star topology: workers hand off back to Router only.

--- a/engine/antigravity_engine/hub/agents.py
+++ b/engine/antigravity_engine/hub/agents.py
@@ -77,8 +77,8 @@ def _import_agent():
         ) from None
 
 
-def _get_model_settings() -> dict:
-    """Get Agent model settings from AG_REASONING_EFFORT env var.
+def _get_model_settings_kwargs() -> dict:
+    """Build Agent kwargs carrying model_settings from AG_REASONING_EFFORT.
 
     ``extra_body`` is the SDK escape hatch for request body fields that are
     not first-class ``Agent`` constructor arguments.
@@ -178,7 +178,7 @@ def build_refresh_swarm(model: str):
         name="ConventionWriter",
         instructions=_CONVENTION_WRITER_INSTRUCTIONS,
         model=model,
-        **_get_model_settings(),
+        **_get_model_settings_kwargs(),
     )
 
     architecture_reviewer = Agent(
@@ -186,7 +186,7 @@ def build_refresh_swarm(model: str):
         instructions=_ARCHITECTURE_REVIEWER_INSTRUCTIONS,
         model=model,
         handoffs=[convention_writer],
-        **_get_model_settings(),
+        **_get_model_settings_kwargs(),
     )
 
     scan_analyst = Agent(
@@ -194,7 +194,7 @@ def build_refresh_swarm(model: str):
         instructions=_SCAN_ANALYST_INSTRUCTIONS,
         model=model,
         handoffs=[architecture_reviewer],
-        **_get_model_settings(),
+        **_get_model_settings_kwargs(),
     )
 
     return scan_analyst
@@ -406,7 +406,7 @@ def build_map_agent(model: str):
         name="MapAgent",
         instructions=_MAP_AGENT_INSTRUCTIONS,
         model=model,
-        **_get_model_settings(),
+        **_get_model_settings_kwargs(),
     )
 
 
@@ -628,7 +628,7 @@ def build_refresh_module_swarm(
             instructions=instructions,
             model=model,
             tools=_wrap_tools(all_tools),
-            **_get_model_settings(),
+            **_get_model_settings_kwargs(),
         )
         agents_list.append((mod, agent))
 
@@ -728,7 +728,7 @@ def build_refresh_module_swarm_v2(
                 name=f"RefreshModule_{mod}_sub{i}_{group.name}",
                 instructions=instructions,
                 model=model,
-                **_get_model_settings(),
+                **_get_model_settings_kwargs(),
             )
             group_entries.append((group.name, group, agent))
 
@@ -767,7 +767,7 @@ def build_refresh_git_agent(model: str, workspace: Path):
         instructions=instructions,
         model=model,
         tools=_wrap_tools(all_tools),
-        **_get_model_settings(),
+        **_get_model_settings_kwargs(),
     )
 
 
@@ -808,7 +808,7 @@ def build_ask_swarm(
                 "the provided context.  Be concise and cite file paths."
             ),
             model=model,
-            **_get_model_settings(),
+            **_get_model_settings_kwargs(),
         )
 
     from antigravity_engine.hub.ask_tools import (
@@ -855,7 +855,7 @@ def build_ask_swarm(
             ),
             model=model,
             tools=wrapped + wrapped_mcp,
-            **_get_model_settings(),
+            **_get_model_settings_kwargs(),
         )
         workers.append(agent)
 
@@ -874,7 +874,7 @@ def build_ask_swarm(
         instructions=_GIT_AGENT_INSTRUCTIONS.format(knowledge=git_knowledge),
         model=model,
         tools=_wrap_tools(git_all_tools) + wrapped_mcp,
-        **_get_model_settings(),
+        **_get_model_settings_kwargs(),
     )
     workers.append(git_agent)
 
@@ -890,7 +890,7 @@ def build_ask_swarm(
         ),
         model=model,
         tools=_wrap_tools(full_tools) + wrapped_mcp,
-        **_get_model_settings(),
+        **_get_model_settings_kwargs(),
     )
     workers.append(full_worker)
 
@@ -925,7 +925,7 @@ def build_ask_swarm(
         instructions=router_instructions,
         model=model,
         handoffs=workers,
-        **_get_model_settings(),
+        **_get_model_settings_kwargs(),
     )
 
     # Star topology: workers hand off back to Router only.

--- a/engine/antigravity_engine/hub/agents.py
+++ b/engine/antigravity_engine/hub/agents.py
@@ -77,19 +77,19 @@ def _import_agent():
         ) from None
 
 
-def _get_reasoning_effort() -> str | None:
-    """Get reasoning_effort from AG_REASONING_EFFORT env var.
+def _get_reasoning_effort() -> dict:
+    """Get reasoning_effort kwargs from AG_REASONING_EFFORT env var.
 
     Passes through any value directly to the OpenAI API.
     Common values: low, medium, high (for o1/o3 models)
-    Returns None if env var is not set.
+    Returns empty dict if env var is not set (for SDK compatibility).
     """
     import os
 
     effort = os.environ.get("AG_REASONING_EFFORT", "").strip()
     if effort:
-        return effort
-    return None
+        return {"reasoning_effort": effort}
+    return {}
 
 
 def _get_stream_enabled() -> bool:
@@ -176,7 +176,7 @@ def build_refresh_swarm(model: str):
         name="ConventionWriter",
         instructions=_CONVENTION_WRITER_INSTRUCTIONS,
         model=model,
-        reasoning_effort=_get_reasoning_effort(),
+        **_get_reasoning_effort(),
         stream=_get_stream_enabled(),
     )
 
@@ -185,7 +185,7 @@ def build_refresh_swarm(model: str):
         instructions=_ARCHITECTURE_REVIEWER_INSTRUCTIONS,
         model=model,
         handoffs=[convention_writer],
-        reasoning_effort=_get_reasoning_effort(),
+        **_get_reasoning_effort(),
         stream=_get_stream_enabled(),
     )
 
@@ -194,7 +194,7 @@ def build_refresh_swarm(model: str):
         instructions=_SCAN_ANALYST_INSTRUCTIONS,
         model=model,
         handoffs=[architecture_reviewer],
-        reasoning_effort=_get_reasoning_effort(),
+        **_get_reasoning_effort(),
         stream=_get_stream_enabled(),
     )
 
@@ -407,7 +407,7 @@ def build_map_agent(model: str):
         name="MapAgent",
         instructions=_MAP_AGENT_INSTRUCTIONS,
         model=model,
-        reasoning_effort=_get_reasoning_effort(),
+        **_get_reasoning_effort(),
         stream=_get_stream_enabled(),
     )
 
@@ -630,7 +630,7 @@ def build_refresh_module_swarm(
             instructions=instructions,
             model=model,
             tools=_wrap_tools(all_tools),
-            reasoning_effort=_get_reasoning_effort(),
+            **_get_reasoning_effort(),
             stream=_get_stream_enabled(),
         )
         agents_list.append((mod, agent))
@@ -731,7 +731,7 @@ def build_refresh_module_swarm_v2(
                 name=f"RefreshModule_{mod}_sub{i}_{group.name}",
                 instructions=instructions,
                 model=model,
-                reasoning_effort=_get_reasoning_effort(),
+                **_get_reasoning_effort(),
                 stream=_get_stream_enabled(),
             )
             group_entries.append((group.name, group, agent))
@@ -771,7 +771,7 @@ def build_refresh_git_agent(model: str, workspace: Path):
         instructions=instructions,
         model=model,
         tools=_wrap_tools(all_tools),
-        reasoning_effort=_get_reasoning_effort(),
+        **_get_reasoning_effort(),
         stream=_get_stream_enabled(),
     )
 
@@ -813,7 +813,7 @@ def build_ask_swarm(
                 "the provided context.  Be concise and cite file paths."
             ),
             model=model,
-            reasoning_effort=_get_reasoning_effort(),
+            **_get_reasoning_effort(),
             stream=_get_stream_enabled(),
         )
 
@@ -861,7 +861,7 @@ def build_ask_swarm(
             ),
             model=model,
             tools=wrapped + wrapped_mcp,
-            reasoning_effort=_get_reasoning_effort(),
+            **_get_reasoning_effort(),
             stream=_get_stream_enabled(),
         )
         workers.append(agent)
@@ -881,7 +881,7 @@ def build_ask_swarm(
         instructions=_GIT_AGENT_INSTRUCTIONS.format(knowledge=git_knowledge),
         model=model,
         tools=_wrap_tools(git_all_tools) + wrapped_mcp,
-        reasoning_effort=_get_reasoning_effort(),
+        **_get_reasoning_effort(),
         stream=_get_stream_enabled(),
     )
     workers.append(git_agent)
@@ -898,7 +898,7 @@ def build_ask_swarm(
         ),
         model=model,
         tools=_wrap_tools(full_tools) + wrapped_mcp,
-        reasoning_effort=_get_reasoning_effort(),
+        **_get_reasoning_effort(),
         stream=_get_stream_enabled(),
     )
     workers.append(full_worker)
@@ -934,7 +934,7 @@ def build_ask_swarm(
         instructions=router_instructions,
         model=model,
         handoffs=workers,
-        reasoning_effort=_get_reasoning_effort(),
+        **_get_reasoning_effort(),
         stream=_get_stream_enabled(),
     )
 

--- a/engine/antigravity_engine/hub/agents.py
+++ b/engine/antigravity_engine/hub/agents.py
@@ -92,6 +92,18 @@ def _get_reasoning_effort() -> str | None:
     return None
 
 
+def _get_stream_enabled() -> bool:
+    """Get stream enabled status from STREAM_ENABLED env var.
+
+    Returns True if env var is set to 'true' (case-insensitive).
+    Default is False for backward compatibility.
+    """
+    import os
+
+    value = os.environ.get("STREAM_ENABLED", "").strip().lower()
+    return value == "true"
+
+
 # ---------------------------------------------------------------------------
 # Refresh Swarm — 3 agents: ScanAnalyst → ArchitectureReviewer → ConventionWriter
 # ---------------------------------------------------------------------------
@@ -165,6 +177,7 @@ def build_refresh_swarm(model: str):
         instructions=_CONVENTION_WRITER_INSTRUCTIONS,
         model=model,
         reasoning_effort=_get_reasoning_effort(),
+        stream=_get_stream_enabled(),
     )
 
     architecture_reviewer = Agent(
@@ -173,6 +186,7 @@ def build_refresh_swarm(model: str):
         model=model,
         handoffs=[convention_writer],
         reasoning_effort=_get_reasoning_effort(),
+        stream=_get_stream_enabled(),
     )
 
     scan_analyst = Agent(
@@ -181,6 +195,7 @@ def build_refresh_swarm(model: str):
         model=model,
         handoffs=[architecture_reviewer],
         reasoning_effort=_get_reasoning_effort(),
+        stream=_get_stream_enabled(),
     )
 
     return scan_analyst
@@ -393,6 +408,7 @@ def build_map_agent(model: str):
         instructions=_MAP_AGENT_INSTRUCTIONS,
         model=model,
         reasoning_effort=_get_reasoning_effort(),
+        stream=_get_stream_enabled(),
     )
 
 
@@ -615,6 +631,7 @@ def build_refresh_module_swarm(
             model=model,
             tools=_wrap_tools(all_tools),
             reasoning_effort=_get_reasoning_effort(),
+            stream=_get_stream_enabled(),
         )
         agents_list.append((mod, agent))
 
@@ -715,6 +732,7 @@ def build_refresh_module_swarm_v2(
                 instructions=instructions,
                 model=model,
                 reasoning_effort=_get_reasoning_effort(),
+                stream=_get_stream_enabled(),
             )
             group_entries.append((group.name, group, agent))
 
@@ -754,6 +772,7 @@ def build_refresh_git_agent(model: str, workspace: Path):
         model=model,
         tools=_wrap_tools(all_tools),
         reasoning_effort=_get_reasoning_effort(),
+        stream=_get_stream_enabled(),
     )
 
 
@@ -795,6 +814,7 @@ def build_ask_swarm(
             ),
             model=model,
             reasoning_effort=_get_reasoning_effort(),
+            stream=_get_stream_enabled(),
         )
 
     from antigravity_engine.hub.ask_tools import (
@@ -842,6 +862,7 @@ def build_ask_swarm(
             model=model,
             tools=wrapped + wrapped_mcp,
             reasoning_effort=_get_reasoning_effort(),
+            stream=_get_stream_enabled(),
         )
         workers.append(agent)
 
@@ -861,6 +882,7 @@ def build_ask_swarm(
         model=model,
         tools=_wrap_tools(git_all_tools) + wrapped_mcp,
         reasoning_effort=_get_reasoning_effort(),
+        stream=_get_stream_enabled(),
     )
     workers.append(git_agent)
 
@@ -877,6 +899,7 @@ def build_ask_swarm(
         model=model,
         tools=_wrap_tools(full_tools) + wrapped_mcp,
         reasoning_effort=_get_reasoning_effort(),
+        stream=_get_stream_enabled(),
     )
     workers.append(full_worker)
 
@@ -912,6 +935,7 @@ def build_ask_swarm(
         model=model,
         handoffs=workers,
         reasoning_effort=_get_reasoning_effort(),
+        stream=_get_stream_enabled(),
     )
 
     # Star topology: workers hand off back to Router only.

--- a/engine/antigravity_engine/hub/agents.py
+++ b/engine/antigravity_engine/hub/agents.py
@@ -177,7 +177,6 @@ def build_refresh_swarm(model: str):
         instructions=_CONVENTION_WRITER_INSTRUCTIONS,
         model=model,
         **_get_reasoning_effort(),
-        stream=_get_stream_enabled(),
     )
 
     architecture_reviewer = Agent(
@@ -186,7 +185,6 @@ def build_refresh_swarm(model: str):
         model=model,
         handoffs=[convention_writer],
         **_get_reasoning_effort(),
-        stream=_get_stream_enabled(),
     )
 
     scan_analyst = Agent(
@@ -195,7 +193,6 @@ def build_refresh_swarm(model: str):
         model=model,
         handoffs=[architecture_reviewer],
         **_get_reasoning_effort(),
-        stream=_get_stream_enabled(),
     )
 
     return scan_analyst
@@ -408,7 +405,6 @@ def build_map_agent(model: str):
         instructions=_MAP_AGENT_INSTRUCTIONS,
         model=model,
         **_get_reasoning_effort(),
-        stream=_get_stream_enabled(),
     )
 
 
@@ -631,7 +627,6 @@ def build_refresh_module_swarm(
             model=model,
             tools=_wrap_tools(all_tools),
             **_get_reasoning_effort(),
-            stream=_get_stream_enabled(),
         )
         agents_list.append((mod, agent))
 
@@ -732,7 +727,6 @@ def build_refresh_module_swarm_v2(
                 instructions=instructions,
                 model=model,
                 **_get_reasoning_effort(),
-                stream=_get_stream_enabled(),
             )
             group_entries.append((group.name, group, agent))
 
@@ -772,7 +766,6 @@ def build_refresh_git_agent(model: str, workspace: Path):
         model=model,
         tools=_wrap_tools(all_tools),
         **_get_reasoning_effort(),
-        stream=_get_stream_enabled(),
     )
 
 
@@ -814,7 +807,6 @@ def build_ask_swarm(
             ),
             model=model,
             **_get_reasoning_effort(),
-            stream=_get_stream_enabled(),
         )
 
     from antigravity_engine.hub.ask_tools import (
@@ -862,7 +854,6 @@ def build_ask_swarm(
             model=model,
             tools=wrapped + wrapped_mcp,
             **_get_reasoning_effort(),
-            stream=_get_stream_enabled(),
         )
         workers.append(agent)
 
@@ -882,7 +873,6 @@ def build_ask_swarm(
         model=model,
         tools=_wrap_tools(git_all_tools) + wrapped_mcp,
         **_get_reasoning_effort(),
-        stream=_get_stream_enabled(),
     )
     workers.append(git_agent)
 
@@ -899,7 +889,6 @@ def build_ask_swarm(
         model=model,
         tools=_wrap_tools(full_tools) + wrapped_mcp,
         **_get_reasoning_effort(),
-        stream=_get_stream_enabled(),
     )
     workers.append(full_worker)
 
@@ -935,7 +924,6 @@ def build_ask_swarm(
         model=model,
         handoffs=workers,
         **_get_reasoning_effort(),
-        stream=_get_stream_enabled(),
     )
 
     # Star topology: workers hand off back to Router only.

--- a/engine/antigravity_engine/hub/ask_pipeline.py
+++ b/engine/antigravity_engine/hub/ask_pipeline.py
@@ -24,8 +24,104 @@ from antigravity_engine.hub.contracts import (
     VerificationResult,
     WorkerEvidence,
 )
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agents.result import RunResult, RunResultStreaming
 
 logger = logging.getLogger(__name__)
+
+
+async def _run_with_optional_stream(
+    agent: "Agent",
+    prompt: str,
+    max_turns: int = 12,
+    timeout: float | None = None,
+    stream_enabled: bool = False,
+    progress_label: str | None = None,
+) -> str:
+    """Execute agent with optional streaming support."""
+    from agents import Runner
+
+    if not stream_enabled:
+        # Non-streaming: use existing pattern
+        if timeout and timeout > 0:
+            result = await asyncio.wait_for(
+                Runner.run(agent, prompt, max_turns=max_turns),
+                timeout=timeout,
+            )
+        else:
+            result = await Runner.run(agent, prompt, max_turns=max_turns)
+        return str(result.final_output)
+
+    # Streaming mode
+    stream_result = Runner.run_streamed(agent, prompt, max_turns=max_turns)
+
+    # For timeout with streaming, wrap the event consumption
+    try:
+        if timeout and timeout > 0:
+            return await asyncio.wait_for(
+                _consume_stream_events(stream_result, progress_label),
+                timeout=timeout,
+            )
+        else:
+            return await _consume_stream_events(stream_result, progress_label)
+    except TimeoutError:
+        await stream_result.cancel()
+        raise
+
+
+async def _consume_stream_events(
+    stream_result: "RunResultStreaming",
+    progress_label: str | None = None,
+) -> str:
+    """Consume streaming events and return final output."""
+    from agents.item_helpers import ItemHelpers
+
+    if progress_label:
+        print(f"[stream] {progress_label}", file=sys.stderr, flush=True)
+
+    async for event in stream_result.stream_events():
+        # Skip raw response events (token-level - too verbose)
+        if event.type == "raw_response_event":
+            continue
+
+        # Track agent changes
+        elif event.type == "agent_updated_stream_event":
+            print(
+                f"[stream] → Agent: {event.new_agent.name}",
+                file=sys.stderr,
+                flush=True,
+            )
+
+        # Handle generated items
+        elif event.type == "run_item_stream_event":
+            item = event.item
+
+            if item.type == "tool_call_item":
+                print("[stream] ⚙ Calling tool...", file=sys.stderr, flush=True)
+
+            elif item.type == "tool_call_output_item":
+                output_preview = str(getattr(item, 'output', ''))[:100]
+                print(
+                    f"[stream] ⚙ Tool output: {output_preview}...",
+                    file=sys.stderr,
+                    flush=True,
+                )
+
+            elif item.type == "message_output_item":
+                content = ItemHelpers.text_message_output(item)
+                if content:
+                    preview = content[:200] if len(content) > 200 else content
+                    if len(content) > 200:
+                        preview += "..."
+                    print(
+                        f"[stream] 📝 {preview}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+
+    return str(stream_result.final_output)
 
 
 async def ask_pipeline(workspace: Path, question: str) -> str:
@@ -146,13 +242,14 @@ async def _ask_with_legacy_swarm(workspace: Path, question: str) -> str:
     ask_timeout = float(os.environ.get("AG_ASK_TIMEOUT_SECONDS", "45"))
     try:
         try:
-            if ask_timeout > 0:
-                result = await asyncio.wait_for(
-                    Runner.run(agent, prompt, max_turns=12),
-                    timeout=ask_timeout,
-                )
-            else:
-                result = await Runner.run(agent, prompt, max_turns=12)
+            result_text = await _run_with_optional_stream(
+                agent=agent,
+                prompt=prompt,
+                max_turns=12,
+                timeout=ask_timeout if ask_timeout > 0 else None,
+                stream_enabled=settings.STREAM_ENABLED,
+                progress_label="Analyzing with multi-agent swarm...",
+            )
         finally:
             if mcp_manager is not None:
                 try:
@@ -164,7 +261,7 @@ async def _ask_with_legacy_swarm(workspace: Path, question: str) -> str:
 
     print("[3/3] Synthesizing answer...", file=sys.stderr)
 
-    return result.final_output
+    return result_text
 
 
 # ---------------------------------------------------------------------------
@@ -423,20 +520,21 @@ Module Map:
         instructions="Output ONLY in the exact format: MODULES: ... and GRAPH: yes/no. No other text.",
         model=model,
     )
+    settings = get_settings()
     ask_timeout = float(os.environ.get("AG_ASK_TIMEOUT_SECONDS", "45"))
     try:
-        if ask_timeout > 0:
-            result = await asyncio.wait_for(
-                Runner.run(router_agent, router_prompt, max_turns=1),
-                timeout=ask_timeout,
-            )
-        else:
-            result = await Runner.run(router_agent, router_prompt, max_turns=1)
+        router_output = await _run_with_optional_stream(
+            agent=router_agent,
+            prompt=router_prompt,
+            max_turns=1,
+            timeout=ask_timeout if ask_timeout > 0 else None,
+            stream_enabled=settings.STREAM_ENABLED,
+            progress_label="Routing question via map.md...",
+        )
     except Exception:
         return None
 
     # Parse Router output: MODULES + GRAPH decision
-    router_output = str(result.final_output).strip()
     raw_modules, needs_graph = _parse_router_output(router_output)
 
     # Collect known module names from agents/ directory
@@ -526,15 +624,16 @@ Knowledge:
             model=model,
         )
         try:
-            if ask_timeout > 0:
-                result = await asyncio.wait_for(
-                    Runner.run(answer_agent, answer_prompt, max_turns=1),
-                    timeout=ask_timeout,
-                )
-            else:
-                result = await Runner.run(answer_agent, answer_prompt, max_turns=1)
+            answer = await _run_with_optional_stream(
+                agent=answer_agent,
+                prompt=answer_prompt,
+                max_turns=1,
+                timeout=ask_timeout if ask_timeout > 0 else None,
+                stream_enabled=settings.STREAM_ENABLED,
+                progress_label="Generating answer from agent.md...",
+            )
             print("[4/4] Answer synthesized.", file=sys.stderr)
-            return str(result.final_output).strip()
+            return answer
         except Exception:
             return None
     else:
@@ -542,6 +641,10 @@ Knowledge:
         async def _answer_from_doc(
             mod_name: str, knowledge: str
         ) -> tuple[str, str | None]:
+            """Answer from a single module's knowledge document.
+
+            Note: streaming is disabled for parallel calls to avoid output interleaving.
+            """
             prompt = f"""\
 Answer this question using ONLY the module knowledge below.
 Be specific — cite file paths, function names.
@@ -561,14 +664,15 @@ Knowledge:
             )
             try:
                 async with _ask_api_sem:
-                    if ask_timeout > 0:
-                        res = await asyncio.wait_for(
-                            Runner.run(agent, prompt, max_turns=1),
-                            timeout=ask_timeout,
-                        )
-                    else:
-                        res = await Runner.run(agent, prompt, max_turns=1)
-                return mod_name, str(res.final_output).strip()
+                    answer = await _run_with_optional_stream(
+                        agent=agent,
+                        prompt=prompt,
+                        max_turns=1,
+                        timeout=ask_timeout if ask_timeout > 0 else None,
+                        stream_enabled=False,
+                        progress_label=None,
+                    )
+                return mod_name, answer
             except Exception:
                 return mod_name, None
 
@@ -609,15 +713,16 @@ Partial answers:
             model=model,
         )
         try:
-            if ask_timeout > 0:
-                result = await asyncio.wait_for(
-                    Runner.run(synth_agent, synth_prompt, max_turns=1),
-                    timeout=ask_timeout,
-                )
-            else:
-                result = await Runner.run(synth_agent, synth_prompt, max_turns=1)
+            answer = await _run_with_optional_stream(
+                agent=synth_agent,
+                prompt=synth_prompt,
+                max_turns=1,
+                timeout=ask_timeout if ask_timeout > 0 else None,
+                stream_enabled=settings.STREAM_ENABLED,
+                progress_label="Synthesizing answers from multiple modules...",
+            )
             print("[4/4] Answer synthesized from multiple modules.", file=sys.stderr)
-            return str(result.final_output).strip()
+            return answer
         except Exception:
             # Return the first valid answer as fallback
             return valid_answers[0][1]

--- a/engine/antigravity_engine/hub/ask_pipeline.py
+++ b/engine/antigravity_engine/hub/ask_pipeline.py
@@ -520,7 +520,6 @@ Module Map:
         instructions="Output ONLY in the exact format: MODULES: ... and GRAPH: yes/no. No other text.",
         model=model,
     )
-    settings = get_settings()
     ask_timeout = float(os.environ.get("AG_ASK_TIMEOUT_SECONDS", "45"))
     try:
         router_output = await _run_with_optional_stream(

--- a/engine/antigravity_engine/hub/refresh_pipeline.py
+++ b/engine/antigravity_engine/hub/refresh_pipeline.py
@@ -140,12 +140,14 @@ async def _run_with_retry(
 
 
 
-async def refresh_pipeline(workspace: Path, quick: bool = False) -> RefreshStatus:
+async def refresh_pipeline(workspace: Path, quick: bool = False, failed_only: bool = False) -> RefreshStatus:
     """Scan project and update .antigravity/conventions.md.
 
     Args:
         workspace: Project root directory.
         quick: If True, only scan files changed since last refresh.
+        failed_only: If True, only re-run modules that failed or were
+            partial in the previous refresh.
 
     Returns:
         Structured refresh status, including stage and module health.
@@ -314,8 +316,43 @@ async def refresh_pipeline(workspace: Path, quick: bool = False) -> RefreshStatu
         refresh_status.stages["knowledge_graph"] = "skipped"
         refresh_status.stages["indexes"] = "skipped"
 
+    modules_filter: list[str] | None = None
+    if failed_only:
+        status_path = ag_dir / "status.json"
+        if status_path.is_file():
+            try:
+                prev_status_raw = json.loads(status_path.read_text(encoding="utf-8"))
+                prev_modules = prev_status_raw.get("modules", {})
+                modules_filter = [
+                    mod for mod, state in prev_modules.items()
+                    if state in ("failed", "partial")
+                ]
+                if modules_filter:
+                    print(
+                        f"[7/8] Failed-only mode: re-running {len(modules_filter)} "
+                        f"failed/partial modules...",
+                        file=sys.stderr,
+                    )
+                else:
+                    print(
+                        "[7/8] Failed-only mode: no failed/partial modules found. "
+                        "Skipping module agents.",
+                        file=sys.stderr,
+                    )
+            except Exception as exc:
+                print(
+                    f"  ⚠ Failed to load previous status: {exc}. "
+                    "Running all modules.",
+                    file=sys.stderr,
+                )
+        else:
+            print(
+                "[7/8] Failed-only mode: no previous status found. "
+                "Running all modules.",
+                file=sys.stderr,
+            )
+
     if not refresh_scan_only:
-        print("[7/8] Module agents learning codebase...", file=sys.stderr)
         from antigravity_engine.hub.agents import (
             build_refresh_module_swarm_v2,
             build_refresh_git_agent,
@@ -329,146 +366,157 @@ async def refresh_pipeline(workspace: Path, quick: bool = False) -> RefreshStatu
                 "OpenAI Agent SDK not found. Install: pip install antigravity-engine"
             ) from None
 
-        module_entries = build_refresh_module_swarm_v2(model, workspace)
-        expected_modules = detect_modules(workspace)
-        module_timeout = float(os.environ.get("AG_MODULE_AGENT_TIMEOUT_SECONDS", "45"))
-        mod_concurrency = int(os.environ.get("AG_REFRESH_CONCURRENCY", "8"))
-        _mod_sem = asyncio.Semaphore(mod_concurrency)
-        # Global API call semaphore: limits total concurrent LLM calls
-        # across ALL modules and groups to avoid rate-limiting.
-        api_concurrency = int(os.environ.get("AG_API_CONCURRENCY", "5"))
-        _api_sem = asyncio.Semaphore(api_concurrency)
-        agents_dir = ag_dir / "agents"
-        agents_dir.mkdir(parents=True, exist_ok=True)
-        # Keep legacy modules dir for backward compat (will be removed in Phase 5)
-        modules_dir = ag_dir / "modules"
-        modules_dir.mkdir(parents=True, exist_ok=True)
+        # Skip module agents when failed-only mode has no modules to process
+        if modules_filter is not None and not modules_filter:
+            print("[7/8] No failed/partial modules to re-run. Skipping module agents.", file=sys.stderr)
+            refresh_status.stages["module_docs"] = "skipped"
+        else:
+            print("[7/8] Module agents learning codebase...", file=sys.stderr)
 
-        async def _run_module(entry: tuple) -> tuple[str, str]:
-            """Run one module's group agents and persist agent.md artifacts.
-
-            For single-group modules: writes ``agents/{module}.md``.
-            For multi-group modules: writes ``agents/{module}/group_N.md``
-            (one per group, no merging).
-
-            Args:
-                entry: Tuple of module name and group agent entries.
-
-            Returns:
-                Module identifier and resulting health state.
-            """
-            async with _mod_sem:
-                mod_name, group_entries = entry
-                num_groups = len(group_entries)
-                print(
-                    f"  → RefreshModule_{mod_name} ({num_groups} groups)...",
-                    file=sys.stderr,
-                )
-
-                async def _run_sub(
-                    group_name: str,
-                    group,
-                    sagent: object,
-                ) -> tuple[str, str | None, str | None]:
-                    """Run one group agent and collect its Markdown output.
-
-                    Args:
-                        group_name: Group identifier within the module.
-                        group: Module grouping object with pre-loaded files.
-                        sagent: Agent instance for the group.
-
-                    Returns:
-                        Tuple of group name, Markdown output, and optional
-                        failure reason.
-                    """
-                    try:
-                        async with _api_sem:
-                            res = await _run_with_retry(
-                                Runner.run,
-                                sagent,
-                                "Analyze the pre-loaded source code and produce a comprehensive Markdown knowledge document.",
-                                max_turns=3,
-                                timeout=module_timeout,
-                                context=f"{mod_name}/{group_name}",
-                            )
-                        md_output = str(res.final_output).strip()
-                        if not md_output:
-                            return group_name, None, "empty output"
-                        print(f"    ✓ {mod_name}/{group_name}", file=sys.stderr)
-                        return group_name, md_output, None
-                    except Exception as exc:
-                        failure_reason = str(exc)
-                        print(f"    ⚠ {mod_name}/{group_name} failed: {failure_reason}", file=sys.stderr)
-                        # Build a minimal fallback from file listing
-                        fallback = _build_agent_md_fallback(mod_name, group_name, group)
-                        return group_name, fallback, failure_reason
-
-                sub_results = await asyncio.gather(
-                    *[_run_sub(gn, grp, sa) for gn, grp, sa in group_entries]
-                )
-
-                successes: list[tuple[str, str]] = []
-                for group_name, md_output, failure_reason in sub_results:
-                    if md_output is None:
-                        _mark_module_failure(
-                            refresh_status,
-                            module=mod_name,
-                            group_name=group_name,
-                            reason=failure_reason or "group returned no output",
-                            state="failed",
-                        )
-                        continue
-                    successes.append((group_name, md_output))
-                    if failure_reason:
-                        _mark_module_failure(
-                            refresh_status,
-                            module=mod_name,
-                            group_name=group_name,
-                            reason=failure_reason,
-                            state="partial",
-                        )
-
-                if not successes:
-                    refresh_status.modules[mod_name] = "failed"
-                    print(f"  ⚠ RefreshModule_{mod_name} produced no output", file=sys.stderr)
-                    return mod_name, "failed"
-
-                # Write agent.md artifacts
-                _write_agent_md_artifacts(
-                    agents_dir=agents_dir,
-                    module=mod_name,
-                    group_outputs=successes,
-                )
-                module_state = "success"
-                if any(reason is not None for _, _, reason in sub_results):
-                    module_state = "partial"
-                refresh_status.modules[mod_name] = module_state
-                print(f"  ✓ RefreshModule_{mod_name} done ({module_state})", file=sys.stderr)
-                return mod_name, module_state
-
-        print(
-            f"  ▶ Running {len(module_entries)} modules "
-            f"(module_concurrency={mod_concurrency}, api_concurrency={api_concurrency})...",
-            file=sys.stderr,
-        )
-        module_results = await asyncio.gather(*[_run_module(e) for e in module_entries])
-        seen_modules = {name for name, _ in module_results}
-        for module_name in expected_modules:
-            if module_name in seen_modules:
-                continue
-            refresh_status.modules[module_name] = "failed"
-            _mark_module_failure(
-                refresh_status,
-                module=module_name,
-                group_name=None,
-                reason="module produced no group agents",
-                state="failed",
+            module_entries = build_refresh_module_swarm_v2(
+                model, workspace, modules_filter=modules_filter
             )
+            expected_modules = detect_modules(workspace)
+            if modules_filter is not None:
+                expected_modules = [m for m in expected_modules if m in modules_filter]
+            module_timeout = float(os.environ.get("AG_MODULE_AGENT_TIMEOUT_SECONDS", "45"))
+            mod_concurrency = int(os.environ.get("AG_REFRESH_CONCURRENCY", "8"))
+            _mod_sem = asyncio.Semaphore(mod_concurrency)
+            # Global API call semaphore: limits total concurrent LLM calls
+            # across ALL modules and groups to avoid rate-limiting.
+            api_concurrency = int(os.environ.get("AG_API_CONCURRENCY", "5"))
+            _api_sem = asyncio.Semaphore(api_concurrency)
+            agents_dir = ag_dir / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            # Keep legacy modules dir for backward compat (will be removed in Phase 5)
+            modules_dir = ag_dir / "modules"
+            modules_dir.mkdir(parents=True, exist_ok=True)
 
-        refresh_status.stages["module_docs"] = _aggregate_states(
-            list(refresh_status.modules.values()),
-            skipped_state="skipped",
-        )
+            async def _run_module(entry: tuple) -> tuple[str, str]:
+                """Run one module's group agents and persist agent.md artifacts.
+
+                For single-group modules: writes ``agents/{module}.md``.
+                For multi-group modules: writes ``agents/{module}/group_N.md``
+                (one per group, no merging).
+
+                Args:
+                    entry: Tuple of module name and group agent entries.
+
+                Returns:
+                    Module identifier and resulting health state.
+                """
+                async with _mod_sem:
+                    mod_name, group_entries = entry
+                    num_groups = len(group_entries)
+                    print(
+                        f"  → RefreshModule_{mod_name} ({num_groups} groups)...",
+                        file=sys.stderr,
+                    )
+
+                    async def _run_sub(
+                        group_name: str,
+                        group,
+                        sagent: object,
+                    ) -> tuple[str, str | None, str | None]:
+                        """Run one group agent and collect its Markdown output.
+
+                        Args:
+                            group_name: Group identifier within the module.
+                            group: Module grouping object with pre-loaded files.
+                            sagent: Agent instance for the group.
+
+                        Returns:
+                            Tuple of group name, Markdown output, and optional
+                            failure reason.
+                        """
+                        try:
+                            async with _api_sem:
+                                res = await _run_with_retry(
+                                    Runner.run,
+                                    sagent,
+                                    "Analyze the pre-loaded source code and produce a comprehensive Markdown knowledge document.",
+                                    max_turns=3,
+                                    timeout=module_timeout,
+                                    context=f"{mod_name}/{group_name}",
+                                )
+                            md_output = str(res.final_output).strip()
+                            if not md_output:
+                                return group_name, None, "empty output"
+                            print(f"    ✓ {mod_name}/{group_name}", file=sys.stderr)
+                            return group_name, md_output, None
+                        except Exception as exc:
+                            failure_reason = str(exc)
+                            print(f"    ⚠ {mod_name}/{group_name} failed: {failure_reason}", file=sys.stderr)
+                            # Build a minimal fallback from file listing
+                            fallback = _build_agent_md_fallback(mod_name, group_name, group)
+                            return group_name, fallback, failure_reason
+
+                    sub_results = await asyncio.gather(
+                        *[_run_sub(gn, grp, sa) for gn, grp, sa in group_entries]
+                    )
+
+                    successes: list[tuple[str, str]] = []
+                    for group_name, md_output, failure_reason in sub_results:
+                        if md_output is None:
+                            _mark_module_failure(
+                                refresh_status,
+                                module=mod_name,
+                                group_name=group_name,
+                                reason=failure_reason or "group returned no output",
+                                state="failed",
+                            )
+                            continue
+                        successes.append((group_name, md_output))
+                        if failure_reason:
+                            _mark_module_failure(
+                                refresh_status,
+                                module=mod_name,
+                                group_name=group_name,
+                                reason=failure_reason,
+                                state="partial",
+                            )
+
+                    if not successes:
+                        refresh_status.modules[mod_name] = "failed"
+                        print(f"  ⚠ RefreshModule_{mod_name} produced no output", file=sys.stderr)
+                        return mod_name, "failed"
+
+                    # Write agent.md artifacts
+                    _write_agent_md_artifacts(
+                        agents_dir=agents_dir,
+                        module=mod_name,
+                        group_outputs=successes,
+                    )
+                    module_state = "success"
+                    if any(reason is not None for _, _, reason in sub_results):
+                        module_state = "partial"
+                    refresh_status.modules[mod_name] = module_state
+                    print(f"  ✓ RefreshModule_{mod_name} done ({module_state})", file=sys.stderr)
+                    return mod_name, module_state
+
+            print(
+                f"  ▶ Running {len(module_entries)} modules "
+                f"(module_concurrency={mod_concurrency}, api_concurrency={api_concurrency})...",
+                file=sys.stderr,
+            )
+            module_results = await asyncio.gather(*[_run_module(e) for e in module_entries])
+            seen_modules = {name for name, _ in module_results}
+            for module_name in expected_modules:
+                if module_name in seen_modules:
+                    continue
+                refresh_status.modules[module_name] = "failed"
+                _mark_module_failure(
+                    refresh_status,
+                    module=module_name,
+                    group_name=None,
+                    reason="module produced no group agents",
+                    state="failed",
+                )
+
+            refresh_status.stages["module_docs"] = _aggregate_states(
+                list(refresh_status.modules.values()),
+                skipped_state="skipped",
+            )
 
         print("  → RefreshGitAgent analyzing git history...", file=sys.stderr)
         try:

--- a/engine/antigravity_engine/hub/refresh_pipeline.py
+++ b/engine/antigravity_engine/hub/refresh_pipeline.py
@@ -108,30 +108,35 @@ async def _run_with_retry(
 
     Returns:
         Result of ``coro_fn``.
-
     Raises:
         The last exception if all retries are exhausted.
     """
     max_retries, base_delay = _get_retry_config(max_retries, base_delay)
     last_exc: Exception | None = None
-    for attempt in range(1, max_retries + 1):
+    for attempt in range(max_retries + 1):
         try:
             if timeout is not None and timeout > 0:
                 return await asyncio.wait_for(coro_fn(*args, **kwargs), timeout=timeout)
             return await coro_fn(*args, **kwargs)
         except Exception as exc:
             last_exc = exc
-            if attempt == max_retries or not _is_retryable_error(exc):
+            # 最后一次尝试失败，抛出异常
+            if attempt >= max_retries:
                 raise
-            delay = base_delay * (2 ** (attempt - 1))
+            # 不可重试的错误，直接抛出
+            if not _is_retryable_error(exc):
+                raise
+            # 计算延迟（指数退避）
+            delay = base_delay * (2 ** attempt)
             label = f" ({context})" if context else ""
+            # 清理错误消息中的换行符，避免日志格式混乱
+            error_msg = str(exc).replace('\n', ' ').replace('\r', '')[:150]
             print(
-                f"  ⚠ Attempt {attempt} failed{label}: {exc}. {delay}s后重试...",
+                f"  ⚠ Attempt {attempt + 1} failed{label}: {error_msg}. {delay}s后重试...",
                 file=sys.stderr,
             )
             await asyncio.sleep(delay)
     raise last_exc
-
 
 
 

--- a/engine/antigravity_engine/hub/refresh_pipeline.py
+++ b/engine/antigravity_engine/hub/refresh_pipeline.py
@@ -30,6 +30,110 @@ from antigravity_engine.hub.contracts import (
 
 logger = logging.getLogger(__name__)
 
+def _get_retry_config(max_retries: int | None = None, base_delay: float | None = None) -> tuple[int, float]:
+    """Read retry configuration from environment variables.
+
+    Args:
+        max_retries: Override for max retries (uses env var if None).
+        base_delay: Override for base delay in seconds (uses env var if None).
+
+    Returns:
+        Tuple of (max_retries, base_delay).
+    """
+    if max_retries is None:
+        try:
+            max_retries = int(os.environ.get("AG_REFRESH_RETRY_COUNT", "3"))
+        except (ValueError, TypeError):
+            max_retries = 3
+    if base_delay is None:
+        try:
+            base_delay = float(os.environ.get("AG_REFRESH_RETRY_DELAY", "1.0"))
+        except (ValueError, TypeError):
+            base_delay = 1.0
+    return max_retries, base_delay
+
+
+def _is_retryable_error(exc: Exception) -> bool:
+    """Check if an exception qualifies for retry.
+
+    Retries on timeout, network errors, rate limits, and 5xx server errors.
+
+    Args:
+        exc: The exception to inspect.
+
+    Returns:
+        True if the error is retryable.
+    """
+    msg = str(exc).lower()
+    retryable_keywords = (
+        "timeout",
+        "gateway time-out",
+        "504",
+        "connection",
+        "network",
+        "unreachable",
+        "refused",
+        "rate limit",
+        "ratelimit",
+        "429",
+        "502",
+        "503",
+        "500",
+        "service unavailable",
+        "bad gateway",
+        "internal server error",
+    )
+    return any(kw in msg for kw in retryable_keywords)
+
+
+async def _run_with_retry(
+    coro_fn,
+    *args,
+    max_retries: int | None = None,
+    base_delay: float | None = None,
+    timeout: float | None = None,
+    context: str = "",
+    **kwargs,
+):
+    """Run an async coroutine with retry and exponential backoff.
+
+    Args:
+        coro_fn: Async callable to execute.
+        *args: Positional arguments for ``coro_fn``.
+        max_retries: Maximum retry attempts (overrides env var).
+        base_delay: Initial delay between retries in seconds (overrides env var).
+        timeout: Per-attempt timeout in seconds (None or <=0 for no timeout).
+        context: Human-readable context string for logging.
+        **kwargs: Keyword arguments for ``coro_fn``.
+
+    Returns:
+        Result of ``coro_fn``.
+
+    Raises:
+        The last exception if all retries are exhausted.
+    """
+    max_retries, base_delay = _get_retry_config(max_retries, base_delay)
+    last_exc: Exception | None = None
+    for attempt in range(1, max_retries + 1):
+        try:
+            if timeout is not None and timeout > 0:
+                return await asyncio.wait_for(coro_fn(*args, **kwargs), timeout=timeout)
+            return await coro_fn(*args, **kwargs)
+        except Exception as exc:
+            last_exc = exc
+            if attempt == max_retries or not _is_retryable_error(exc):
+                raise
+            delay = base_delay * (2 ** (attempt - 1))
+            label = f" ({context})" if context else ""
+            print(
+                f"  ⚠ Attempt {attempt} failed{label}: {exc}. {delay}s后重试...",
+                file=sys.stderr,
+            )
+            await asyncio.sleep(delay)
+    raise last_exc
+
+
+
 
 async def refresh_pipeline(workspace: Path, quick: bool = False) -> RefreshStatus:
     """Scan project and update .antigravity/conventions.md.
@@ -141,10 +245,11 @@ async def refresh_pipeline(workspace: Path, quick: bool = False) -> RefreshStatu
 
         refresh_timeout = float(os.environ.get("AG_REFRESH_AGENT_TIMEOUT_SECONDS", "90"))
         try:
-            if refresh_timeout > 0:
-                result = await asyncio.wait_for(Runner.run(agent, prompt), timeout=refresh_timeout)
-            else:
-                result = await Runner.run(agent, prompt)
+            result = await _run_with_retry(
+                Runner.run, agent, prompt,
+                timeout=refresh_timeout,
+                context="Conventions swarm",
+            )
             conventions_content = result.final_output
             refresh_status.stages["conventions"] = "success"
         except Exception as exc:
@@ -273,21 +378,14 @@ async def refresh_pipeline(workspace: Path, quick: bool = False) -> RefreshStatu
                     """
                     try:
                         async with _api_sem:
-                            if module_timeout > 0:
-                                res = await asyncio.wait_for(
-                                    Runner.run(
-                                        sagent,
-                                        "Analyze the pre-loaded source code and produce a comprehensive Markdown knowledge document.",
-                                        max_turns=3,
-                                    ),
-                                    timeout=module_timeout,
-                                )
-                            else:
-                                res = await Runner.run(
-                                    sagent,
-                                    "Analyze the pre-loaded source code and produce a comprehensive Markdown knowledge document.",
-                                    max_turns=3,
-                                )
+                            res = await _run_with_retry(
+                                Runner.run,
+                                sagent,
+                                "Analyze the pre-loaded source code and produce a comprehensive Markdown knowledge document.",
+                                max_turns=3,
+                                timeout=module_timeout,
+                                context=f"{mod_name}/{group_name}",
+                            )
                         md_output = str(res.final_output).strip()
                         if not md_output:
                             return group_name, None, "empty output"
@@ -370,21 +468,14 @@ async def refresh_pipeline(workspace: Path, quick: bool = False) -> RefreshStatu
         print("  → RefreshGitAgent analyzing git history...", file=sys.stderr)
         try:
             git_agent = build_refresh_git_agent(model, workspace)
-            if module_timeout > 0:
-                await asyncio.wait_for(
-                    Runner.run(
-                        git_agent,
-                        "Analyze the project's git history and write your git insights document.",
-                        max_turns=25,
-                    ),
-                    timeout=module_timeout,
-                )
-            else:
-                await Runner.run(
-                    git_agent,
-                    "Analyze the project's git history and write your git insights document.",
-                    max_turns=25,
-                )
+            await _run_with_retry(
+                Runner.run,
+                git_agent,
+                "Analyze the project's git history and write your git insights document.",
+                max_turns=25,
+                timeout=module_timeout,
+                context="Git agent",
+            )
             refresh_status.stages["git_insights"] = "success"
         except Exception as exc:
             print(f"  ⚠ RefreshGitAgent failed: {exc}", file=sys.stderr)
@@ -1750,13 +1841,11 @@ async def _generate_map_md(workspace: Path, model: str) -> str:
 
     async def _run_map_batch(batch: list[str], batch_idx: int) -> str:
         prompt = "Create a map.md from these module knowledge documents:\n" + "\n".join(batch)
-        if map_timeout > 0:
-            result = await asyncio.wait_for(
-                Runner.run(map_agent, prompt),
-                timeout=map_timeout,
-            )
-        else:
-            result = await Runner.run(map_agent, prompt)
+        result = await _run_with_retry(
+            Runner.run, map_agent, prompt,
+            timeout=map_timeout,
+            context=f"Map agent batch {batch_idx}",
+        )
         return str(result.final_output).strip()
 
     if len(batches) == 1:
@@ -1947,13 +2036,11 @@ Output ONLY the Markdown registry. Start with `# Module Registry`.
     )
 
     registry_timeout = float(os.environ.get("AG_REGISTRY_TIMEOUT_SECONDS", "60"))
-    if registry_timeout > 0:
-        result = await asyncio.wait_for(
-            Runner.run(registry_agent, prompt),
-            timeout=registry_timeout,
-        )
-    else:
-        result = await Runner.run(registry_agent, prompt)
+    result = await _run_with_retry(
+        Runner.run, registry_agent, prompt,
+        timeout=registry_timeout,
+        context="Registry agent",
+    )
 
     return result.final_output
 

--- a/engine/antigravity_engine/hub/refresh_pipeline.py
+++ b/engine/antigravity_engine/hub/refresh_pipeline.py
@@ -120,23 +120,23 @@ async def _run_with_retry(
             return await coro_fn(*args, **kwargs)
         except Exception as exc:
             last_exc = exc
-            # 最后一次尝试失败，抛出异常
+            # Last attempt failed, re-raise
             if attempt >= max_retries:
                 raise
-            # 不可重试的错误，直接抛出
+            # Non-retryable error, re-raise immediately
             if not _is_retryable_error(exc):
                 raise
-            # 计算延迟（指数退避）
+            # Calculate delay (exponential backoff)
             delay = base_delay * (2 ** attempt)
             label = f" ({context})" if context else ""
-            # 清理错误消息中的换行符，避免日志格式混乱
+            # Clean newlines from error message to prevent log format issues
             error_msg = str(exc).replace('\n', ' ').replace('\r', '')[:150]
             print(
-                f"  ⚠ Attempt {attempt + 1} failed{label}: {error_msg}. {delay}s后重试...",
+                f"  ⚠ Attempt {attempt + 1} failed{label}: {error_msg}. Retrying in {delay}s...",
                 file=sys.stderr,
             )
             await asyncio.sleep(delay)
-    raise last_exc
+    # Unreachable - loop always returns or raises
 
 
 

--- a/engine/tests/test_hub_agents_import.py
+++ b/engine/tests/test_hub_agents_import.py
@@ -1,5 +1,6 @@
 """Tests for hub agent ImportError handling and area detection."""
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -22,6 +23,56 @@ def test_build_ask_swarm_import_error():
     with patch.dict(sys.modules, {"agents": None}):
         with pytest.raises(ImportError, match="OpenAI Agent SDK not found"):
             build_ask_swarm("test-model")
+
+
+def test_reasoning_effort_is_passed_through_model_settings_extra_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AG_REASONING_EFFORT is sent through ModelSettings.extra_body."""
+    from antigravity_engine.hub.agents import build_refresh_swarm
+
+    class ModelSettings:
+        def __init__(self, extra_body: dict[str, str] | None = None) -> None:
+            self.extra_body = extra_body
+
+    class Agent:
+        instances: list["Agent"] = []
+
+        def __init__(
+            self,
+            name: str,
+            instructions: str,
+            model: str,
+            handoffs: list["Agent"] | None = None,
+            model_settings: ModelSettings | None = None,
+        ) -> None:
+            self.name = name
+            self.instructions = instructions
+            self.model = model
+            self.handoffs = handoffs or []
+            self.model_settings = model_settings
+            Agent.instances.append(self)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "agents",
+        types.SimpleNamespace(Agent=Agent, ModelSettings=ModelSettings),
+    )
+    monkeypatch.setenv("AG_REASONING_EFFORT", "high")
+
+    swarm = build_refresh_swarm("test-model")
+
+    assert swarm.name == "ScanAnalyst"
+    assert [agent.name for agent in Agent.instances] == [
+        "ConventionWriter",
+        "ArchitectureReviewer",
+        "ScanAnalyst",
+    ]
+    assert [agent.model_settings.extra_body for agent in Agent.instances] == [
+        {"reasoning_effort": "high"},
+        {"reasoning_effort": "high"},
+        {"reasoning_effort": "high"},
+    ]
 
 
 def test_detect_areas_finds_source_dirs(tmp_path: Path) -> None:


### PR DESCRIPTION
## 主要功能更新

### 1. 重试机制增强
- 为 refresh pipeline 的 LLM 调用添加指数退避重试机制
- 提升在临时网络故障或 API 限流情况下的稳定性

### 2. 增量刷新支持
- 新增 `--failed-only` 标志，允许仅刷新之前失败的模块
- 避免重复处理已成功模块，显著提升大规模项目的迭代效率

### 3. 模型推理强度支持
- 通过 `AG_REASONING_EFFORT` 环境变量控制模型推理强度
- 使用 `ModelSettings.extra_body` 正确传递参数，确保与最新 Agents SDK 兼容
- 条件化处理，未设置环境变量时保持向后兼容
- 具体取值取决于推理平台的自定义配置

### 4. 流式响应支持
- 通过 `STREAM_ENABLED` 环境变量开启流式响应
- 重构流式实现方式，改用 `Runner.run_streamed()` API
- 移除 Agent 构造函数中不受支持的 `stream` 参数


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--failed-only` option to refresh to retry only previously failed/partial modules
  * Optional streaming support for LLM responses (env-configurable)
  * New reasoning-effort configuration for LLM interactions

* **Improvements**
  * Centralized retry orchestration with exponential backoff and configurable retry behavior
  * Refresh now skips work cleanly when nothing matches `--failed-only`

* **Tests**
  * Added unit test verifying reasoning-effort is propagated to agent model settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->