### PR TITLE
docs: SEO-optimize README H1 and subtitle for AI IDE discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <img src="docs/assets/logo.png" alt="Antigravity Workspace" width="200"/>
 
-# AI Workspace Template
+# Antigravity — Workspace Template for Claude Code, Codex CLI & Cursor
 
-### Multi-agent knowledge engine for any codebase.
+### Multi-agent knowledge engine + MCP server that turns any repo into a queryable AI assistant. Works with Claude Code, Codex CLI, Cursor, Windsurf, and Gemini CLI.
 
 `ag-refresh` builds a knowledge base. `ag-ask` answers questions. Any LLM, any IDE.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -2,9 +2,9 @@
 
 <img src="docs/assets/logo.png" alt="Antigravity Workspace" width="200"/>
 
-# AI Workspace Template
+# Antigravity 工作区模板 — Claude Code / Codex / Cursor 起手套件
 
-### 面向任意代码库的多智能体知识引擎。
+### 多智能体知识引擎 + MCP 服务。把任意代码库变成可问答的 AI 工作区。支持 Claude Code、Codex CLI、Cursor、Windsurf、Gemini CLI。
 
 `ag-refresh` 构建知识库。`ag-ask` 回答问题。任意 LLM，任意 IDE。
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -2,9 +2,9 @@
 
 <img src="docs/assets/logo.png" alt="Antigravity Workspace" width="200"/>
 
-# AI Workspace Template
+# Antigravity — Plantilla de Workspace para Claude Code, Codex CLI y Cursor
 
-### Motor de conocimiento multi-agente para cualquier codebase.
+### Motor de conocimiento multi-agente + servidor MCP que convierte cualquier repositorio en un asistente de IA consultable. Compatible con Claude Code, Codex CLI, Cursor, Windsurf y Gemini CLI.
 
 `ag-refresh` construye la base de conocimiento. `ag-ask` responde preguntas. Cualquier LLM, cualquier IDE.
 


### PR DESCRIPTION
## Summary
- Replaces generic `# AI Workspace Template` H1 with a keyword-rich title across all three language READMEs (EN / CN / ES)
- Subtitle now explicitly mentions **MCP server** and the supported IDE matrix (Claude Code, Codex CLI, Cursor, Windsurf, Gemini CLI) so Google snippets carry useful context
- Pure 6-line diff (2 lines × 3 READMEs) — no other content changed

## Why
Traffic insights (last 14 days) showed Google was the dominant referrer (~53% of visits) but the previous H1 contained zero high-search-volume keywords. The repo was discoverable through search but not competing on terms like "Claude Code template", "Codex CLI starter", or "agentic coding workspace".

## After this merge
- Repo description (About) and topics already updated separately
- Once merged into `main`, request re-indexing in [Google Search Console](https://search.google.com/search-console) → URL Inspection → "Request Indexing" for faster pickup

## Test plan
- [x] Diff reviewed: 6-line change, no encoding/format regressions
- [ ] Merge to main
- [ ] Verify rendered H1 on https://github.com/study8677/antigravity-workspace-template
- [ ] Submit URL for re-indexing in Search Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README documentation in English, Chinese, and Spanish to clarify product branding and explicitly list supported IDE integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->