### PR TITLE
feat: package as Claude Code & Codex CLI plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "antigravity",
+  "owner": {
+    "name": "Antigravity Team",
+    "email": "fanjingwen50@gmail.com",
+    "url": "https://github.com/study8677/antigravity-workspace-template"
+  },
+  "plugins": [
+    {
+      "name": "antigravity",
+      "source": ".",
+      "description": "Multi-agent knowledge hub: ask_project / refresh_project MCP tools, agent-repo-init skill, and the ag CLI.",
+      "version": "0.2.0",
+      "category": "developer-tools",
+      "keywords": ["mcp", "knowledge-graph", "multi-agent", "scaffolding"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "antigravity",
+  "version": "0.2.0",
+  "description": "Multi-agent knowledge hub plugin. Bundles ag-mcp (ask_project/refresh_project), the ag CLI, and the agent-repo-init skill.",
+  "author": {
+    "name": "Antigravity Team",
+    "email": "fanjingwen50@gmail.com"
+  },
+  "homepage": "https://github.com/study8677/antigravity-workspace-template",
+  "license": "MIT",
+  "keywords": ["mcp", "knowledge-graph", "scaffolding", "multi-agent"],
+  "skills": "./skills/",
+  "commands": "./commands/",
+  "hooks": "./hooks/hooks.json",
+  "mcpServers": {
+    "antigravity": {
+      "command": "ag-mcp",
+      "args": ["--workspace", "${CLAUDE_PROJECT_DIR}"],
+      "env": {}
+    }
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "antigravity",
+  "version": "0.2.0",
+  "description": "Multi-agent knowledge hub plugin (Codex CLI). Provides ask_project/refresh_project MCP tools and the agent-repo-init skill.",
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "antigravity": {
+      "command": "ag-mcp",
+      "args": [],
+      "env": {}
+    }
+  }
+}

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,77 @@
+# Installing the Antigravity plugin
+
+## Claude Code
+
+```
+/plugin marketplace add /absolute/path/to/antigravity-workspace-template
+/plugin install antigravity@antigravity
+```
+
+The first session after install runs `hooks/install_engine.sh`, which auto-installs the engine via `pipx` (preferred) or `pip --user`. If both fail, follow the printed manual command and restart the session.
+
+You can also add the marketplace directly from GitHub:
+
+```
+/plugin marketplace add study8677/antigravity-workspace-template
+/plugin install antigravity@antigravity
+```
+
+## Codex CLI
+
+Codex CLI does not auto-run install hooks (as of April 2026), so install the engine first:
+
+```
+pipx install /absolute/path/to/antigravity-workspace-template/engine
+ag-mcp --help    # verify
+```
+
+Then register and install the plugin:
+
+```
+codex plugin marketplace add /absolute/path/to/antigravity-workspace-template
+codex plugin install antigravity
+```
+
+## Verifying
+
+- **Claude Code**: `/ag-ask "what does the engine do?"` should invoke `mcp__antigravity__ask_project`.
+- **Codex CLI**: confirm the `antigravity` MCP server appears in your Codex MCP server list.
+
+## Available slash commands (Claude Code)
+
+| Command | What it does |
+|---|---|
+| `/ag-ask <question>` | Routed Q&A on the current codebase |
+| `/ag-refresh [quick]` | Rebuild the project knowledge base |
+| `/ag-init <name>` | Scaffold a new multi-agent repo from this template |
+
+## Bundled MCP tools
+
+After install, the `antigravity` MCP server exposes:
+
+- `ask_project(question)` — routed Q&A with file paths and line numbers
+- `refresh_project(quick=False)` — rebuild knowledge base
+
+## Uninstall
+
+```
+pipx uninstall antigravity-engine
+/plugin uninstall antigravity
+```
+
+## Requirements
+
+- Python 3.10+ on PATH (`python3` / `python`)
+- `pipx` recommended (`brew install pipx`, `apt install pipx`, or `python3 -m pip install --user pipx`)
+- Network access on first launch (for the auto-installer)
+
+## Troubleshooting
+
+**`ag-mcp` not found after install**
+The user-pip bin directory may not be on PATH. The installer prints the path; add it to your shell rc file (`~/.zshrc`, `~/.bashrc`, etc.).
+
+**Hook timed out**
+Slow network during first install. Increase the `timeout` in `hooks/hooks.json` or run `pipx install <plugin-root>/engine` manually before restarting.
+
+**Codex CLI marketplace add fails**
+Codex's marketplace schema is partially undocumented. If `codex plugin marketplace add <path>` rejects the repo, you can still register the MCP server directly via your local Codex CLI MCP config and load skills from `<path>/skills/` manually.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,21 @@ Architecture is **files + a live Q&A engine**, not plugins. Portable across any 
 
 ## Quick Start
 
-**Option A — Engine: multi-agent Q&A on your codebase (recommended)**
+**Option A — One-line install as a Claude Code / Codex CLI plugin (recommended)**
+```bash
+# Claude Code (auto-installs the Python engine on first session via SessionStart hook)
+/plugin marketplace add study8677/antigravity-workspace-template
+/plugin install antigravity@antigravity
+
+# Codex CLI (install the engine manually first; Codex hooks are not yet supported)
+pipx install "git+https://github.com/study8677/antigravity-workspace-template.git#subdirectory=engine"
+codex plugin marketplace add study8677/antigravity-workspace-template
+codex plugin install antigravity
+```
+
+After install you get `/ag-ask <question>`, `/ag-refresh`, `/ag-init <name>` slash commands plus the `antigravity` MCP server (`ask_project` + `refresh_project`). See [INSTALL.md](INSTALL.md) for details and troubleshooting.
+
+**Option B — Manual install: engine + CLI via pip**
 ```bash
 # 1. Install engine + CLI
 pip install "git+https://github.com/study8677/antigravity-workspace-template.git#subdirectory=cli"
@@ -92,7 +106,7 @@ ag-ask "How does auth work in this project?"
 claude mcp add antigravity ag-mcp -- --workspace $(pwd)
 ```
 
-**Option B — Context files only (any IDE, no LLM needed)**
+**Option C — Context files only (any IDE, no LLM needed)**
 ```bash
 pip install git+https://github.com/study8677/antigravity-workspace-template.git#subdirectory=cli
 ag init my-project && cd my-project

--- a/README_CN.md
+++ b/README_CN.md
@@ -67,7 +67,21 @@
 
 ## 快速开始
 
-**方案 A —— 引擎：多智能体代码问答（推荐）**
+**方案 A —— 作为 Claude Code / Codex CLI 插件一行安装（推荐）**
+```bash
+# Claude Code（首次会话由 SessionStart hook 自动安装 Python 引擎）
+/plugin marketplace add study8677/antigravity-workspace-template
+/plugin install antigravity@antigravity
+
+# Codex CLI（需手动先装引擎；Codex 暂不支持自动 hook）
+pipx install "git+https://github.com/study8677/antigravity-workspace-template.git#subdirectory=engine"
+codex plugin marketplace add study8677/antigravity-workspace-template
+codex plugin install antigravity
+```
+
+安装后即可使用 `/ag-ask <问题>`、`/ag-refresh`、`/ag-init <名字>` 斜杠命令，以及 `antigravity` MCP 服务（`ask_project` + `refresh_project`）。详见 [INSTALL.md](INSTALL.md)。
+
+**方案 B —— 手动安装：通过 pip 安装引擎 + CLI**
 ```bash
 # 1. 安装引擎 + CLI
 pip install "git+https://github.com/study8677/antigravity-workspace-template.git#subdirectory=cli"
@@ -92,7 +106,7 @@ ag-ask "这个项目的认证逻辑是怎么实现的？"
 claude mcp add antigravity ag-mcp -- --workspace $(pwd)
 ```
 
-**方案 B —— 仅注入上下文文件（任意 IDE，无需 LLM）**
+**方案 C —— 仅注入上下文文件（任意 IDE，无需 LLM）**
 ```bash
 pip install git+https://github.com/study8677/antigravity-workspace-template.git#subdirectory=cli
 ag init my-project && cd my-project

--- a/README_ES.md
+++ b/README_ES.md
@@ -67,7 +67,21 @@ La arquitectura son **archivos + un motor Q&A en vivo**, no plugins. Portable en
 
 ## Inicio Rápido
 
-**Opción A — Motor: Q&A multi-agente sobre tu codebase (recomendado)**
+**Opción A — Instalación de una línea como plugin de Claude Code / Codex CLI (recomendado)**
+```bash
+# Claude Code (auto-instala el motor Python en la primera sesión vía SessionStart hook)
+/plugin marketplace add study8677/antigravity-workspace-template
+/plugin install antigravity@antigravity
+
+# Codex CLI (instala el motor manualmente primero; los hooks de Codex aún no son soportados)
+pipx install "git+https://github.com/study8677/antigravity-workspace-template.git#subdirectory=engine"
+codex plugin marketplace add study8677/antigravity-workspace-template
+codex plugin install antigravity
+```
+
+Después de instalar dispondrás de los comandos slash `/ag-ask <pregunta>`, `/ag-refresh`, `/ag-init <nombre>`, y del servidor MCP `antigravity` (`ask_project` + `refresh_project`). Ver [INSTALL.md](INSTALL.md) para detalles y solución de problemas.
+
+**Opción B — Instalación manual: motor + CLI vía pip**
 ```bash
 # 1. Instalar motor + CLI
 pip install "git+https://github.com/study8677/antigravity-workspace-template.git#subdirectory=cli"
@@ -92,7 +106,7 @@ ag-ask "¿Cómo funciona la autenticación en este proyecto?"
 claude mcp add antigravity ag-mcp -- --workspace $(pwd)
 ```
 
-**Opción B — Solo archivos de contexto (cualquier IDE, sin LLM)**
+**Opción C — Solo archivos de contexto (cualquier IDE, sin LLM)**
 ```bash
 pip install git+https://github.com/study8677/antigravity-workspace-template.git#subdirectory=cli
 ag init mi-proyecto && cd mi-proyecto

--- a/commands/ag-ask.md
+++ b/commands/ag-ask.md
@@ -1,0 +1,10 @@
+---
+description: Ask a question about the current project's codebase via the antigravity knowledge hub.
+allowed-tools: ["mcp__antigravity__ask_project"]
+---
+
+Use the `mcp__antigravity__ask_project` MCP tool to answer:
+
+> $ARGUMENTS
+
+Prefer this tool over manual file search. If the tool returns insufficient detail, follow up with targeted Read/Grep.

--- a/commands/ag-init.md
+++ b/commands/ag-init.md
@@ -1,0 +1,5 @@
+---
+description: Scaffold a new multi-agent repository from the Antigravity template (invokes agent-repo-init skill).
+---
+
+Invoke the `agent-repo-init` skill. Parse $ARGUMENTS for: project name, destination path, mode (`quick` or `full`). If any are missing, ask before running `${CLAUDE_PLUGIN_ROOT}/skills/agent-repo-init/scripts/init_project.py`.

--- a/commands/ag-refresh.md
+++ b/commands/ag-refresh.md
@@ -1,0 +1,10 @@
+---
+description: Rebuild the antigravity project knowledge base after significant changes.
+allowed-tools: ["mcp__antigravity__refresh_project"]
+---
+
+Call `mcp__antigravity__refresh_project` for the current workspace.
+
+If $ARGUMENTS contains "quick" → pass `quick=true`. Otherwise pass `quick=false`.
+
+Report progress concisely; full refresh can take several minutes.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/install_engine.sh",
+            "timeout": 300
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/install_engine.bat
+++ b/hooks/install_engine.bat
@@ -1,0 +1,31 @@
+@echo off
+REM SessionStart hook (Windows). Mirrors install_engine.sh.
+setlocal
+
+set "PLUGIN_ROOT=%CLAUDE_PLUGIN_ROOT%"
+if "%PLUGIN_ROOT%"=="" set "PLUGIN_ROOT=%~dp0.."
+
+where ag-mcp >nul 2>&1
+if not errorlevel 1 exit /b 0
+
+echo [antigravity] ag-mcp not found. Attempting auto-install... 1>&2
+
+where pipx >nul 2>&1
+if not errorlevel 1 (
+    pipx install "%PLUGIN_ROOT%\engine" 1>&2 2>&1
+    where ag-mcp >nul 2>&1
+    if not errorlevel 1 exit /b 0
+)
+
+where python >nul 2>&1
+if not errorlevel 1 (
+    python -m pip install --user --quiet "%PLUGIN_ROOT%\engine" "%PLUGIN_ROOT%\cli" 1>&2 2>&1
+    where ag-mcp >nul 2>&1
+    if not errorlevel 1 exit /b 0
+)
+
+echo [antigravity] AUTO-INSTALL FAILED. Run manually: 1>&2
+echo   pipx install "%PLUGIN_ROOT%\engine" 1>&2
+echo   - or - 1>&2
+echo   python -m pip install --user "%PLUGIN_ROOT%\engine" "%PLUGIN_ROOT%\cli" 1>&2
+exit /b 1

--- a/hooks/install_engine.sh
+++ b/hooks/install_engine.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# SessionStart hook: ensure ag-mcp is on PATH. Idempotent and silent on the happy path.
+set -u
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+
+if command -v ag-mcp >/dev/null 2>&1; then
+  exit 0
+fi
+
+echo "[antigravity] ag-mcp not found. Attempting auto-install..." >&2
+
+if command -v pipx >/dev/null 2>&1; then
+  if pipx install "${PLUGIN_ROOT}/engine" 1>&2 2>&1; then
+    if command -v ag-mcp >/dev/null 2>&1; then
+      echo "[antigravity] Installed via pipx." >&2
+      exit 0
+    fi
+  fi
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+  if python3 -m pip install --user --quiet "${PLUGIN_ROOT}/engine" "${PLUGIN_ROOT}/cli" 1>&2 2>&1; then
+    USER_BIN="$(python3 -c 'import site,os;print(os.path.join(site.USER_BASE,"bin"))' 2>/dev/null || true)"
+    if [ -x "${USER_BIN}/ag-mcp" ] || command -v ag-mcp >/dev/null 2>&1; then
+      echo "[antigravity] Installed via pip --user. If 'ag-mcp' still missing from PATH, add: ${USER_BIN}" >&2
+      exit 0
+    fi
+  fi
+fi
+
+cat >&2 <<EOF
+[antigravity] AUTO-INSTALL FAILED. Run ONE of these manually:
+
+  Option A (recommended):
+    pipx install "${PLUGIN_ROOT}/engine"
+
+  Option B:
+    python3 -m pip install --user "${PLUGIN_ROOT}/engine" "${PLUGIN_ROOT}/cli"
+
+Then ensure the bin dir is on PATH and restart your Claude Code session.
+EOF
+exit 1


### PR DESCRIPTION
## Summary

- Adds plugin marketplace + plugin manifests so the repo is installable via `/plugin marketplace add` + `/plugin install` (Claude Code) and `codex plugin marketplace add` + `codex plugin install` (Codex CLI)
- Wires the existing `agent-repo-init` skill, the `ag-mcp` MCP server (`ask_project` / `refresh_project`), and three slash commands (`/ag-ask`, `/ag-refresh`, `/ag-init`)
- Adds a `SessionStart` hook that auto-installs the Python engine via `pipx` (preferred) or `pip --user`, with a clear manual-install fallback message on failure
- Promotes the plugin install flow to **Option A (recommended)** in README.md / README_CN.md / README_ES.md

## Files added

- `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json` — Claude Code wiring
- `.codex-plugin/plugin.json` + `.mcp.json` — Codex CLI wiring
- `commands/ag-{ask,refresh,init}.md` — slash commands
- `hooks/{hooks.json,install_engine.sh,install_engine.bat}` — SessionStart auto-install
- `INSTALL.md` — user install + verification guide

Existing `engine/`, `cli/`, `skills/agent-repo-init/`, and `mcp_servers.json` are untouched.

## Test plan

- [ ] `/plugin marketplace add /path/to/repo` succeeds in Claude Code
- [ ] `/plugin install antigravity@antigravity` succeeds
- [ ] First new session triggers `install_engine.sh`; `[antigravity] Installed via pipx.` appears on stderr
- [ ] `which ag-mcp` returns a valid path after install
- [ ] `/ag-ask "describe the engine"` invokes `mcp__antigravity__ask_project`
- [ ] `/ag-refresh quick` runs incremental refresh
- [ ] `/ag-init` triggers the agent-repo-init skill
- [ ] On Codex CLI: after manual `pipx install .../engine`, `codex plugin install antigravity` registers the `antigravity` MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)