### PR TITLE
fix(plugin): use github source type in marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,10 @@
   "plugins": [
     {
       "name": "antigravity",
-      "source": ".",
+      "source": {
+        "source": "github",
+        "repo": "study8677/antigravity-workspace-template"
+      },
       "description": "Multi-agent knowledge hub: ask_project / refresh_project MCP tools, agent-repo-init skill, and the ag CLI.",
       "version": "0.2.0",
       "category": "developer-tools",


### PR DESCRIPTION
## Summary

Fixes the schema validation error reported by `/plugin marketplace add`:

\`\`\`
Failed to parse marketplace file: Invalid schema:
plugins.0.source: Invalid input
\`\`\`

The string source `"."` is rejected by the marketplace validator. Switching to the explicit `github` source type is the documented form for plugins that live at the repository root.

## After this merges

\`\`\`
/plugin marketplace remove study8677-antigravity-workspace-template   # clear stale cache
/plugin marketplace add study8677/antigravity-workspace-template
/plugin install antigravity@antigravity
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)