### PR TITLE
fix(plugin): auto-install pipx in SessionStart hook

### DIFF
--- a/hooks/install_engine.sh
+++ b/hooks/install_engine.sh
@@ -10,6 +10,36 @@ fi
 
 echo "[antigravity] ag-mcp not found. Attempting auto-install..." >&2
 
+# Step 1: ensure pipx exists.
+#
+# Hook runs without a TTY, so anything requiring `sudo` will hang. We pick the
+# safest available path:
+#   - macOS with Homebrew → `brew install pipx` (no sudo)
+#   - Anything else with python3 → `pip install --user pipx` (no sudo)
+# Linux users who prefer `apt`/`dnf` get a clear instruction in the final
+# fallback message below.
+if ! command -v pipx >/dev/null 2>&1; then
+  if command -v brew >/dev/null 2>&1; then
+    echo "[antigravity] Installing pipx via Homebrew..." >&2
+    brew install pipx 1>&2 2>&1 || true
+  elif command -v python3 >/dev/null 2>&1; then
+    echo "[antigravity] Installing pipx via pip --user..." >&2
+    python3 -m pip install --user --quiet pipx 1>&2 2>&1 || true
+    if [ -d "${HOME}/.local/bin" ]; then
+      export PATH="${HOME}/.local/bin:${PATH}"
+    fi
+  fi
+fi
+
+# Step 2: ensure pipx is on PATH (ensurepath is a no-op if already configured).
+if command -v pipx >/dev/null 2>&1; then
+  pipx ensurepath 1>&2 2>&1 || true
+  if [ -d "${HOME}/.local/bin" ]; then
+    export PATH="${HOME}/.local/bin:${PATH}"
+  fi
+fi
+
+# Step 3: install antigravity-engine via pipx.
 if command -v pipx >/dev/null 2>&1; then
   if pipx install "${PLUGIN_ROOT}/engine" 1>&2 2>&1; then
     if command -v ag-mcp >/dev/null 2>&1; then
@@ -19,11 +49,15 @@ if command -v pipx >/dev/null 2>&1; then
   fi
 fi
 
+# Step 4: fallback to pip --user if pipx is still unavailable.
 if command -v python3 >/dev/null 2>&1; then
   if python3 -m pip install --user --quiet "${PLUGIN_ROOT}/engine" "${PLUGIN_ROOT}/cli" 1>&2 2>&1; then
     USER_BIN="$(python3 -c 'import site,os;print(os.path.join(site.USER_BASE,"bin"))' 2>/dev/null || true)"
+    if [ -n "${USER_BIN}" ] && [ -d "${USER_BIN}" ]; then
+      export PATH="${USER_BIN}:${PATH}"
+    fi
     if [ -x "${USER_BIN}/ag-mcp" ] || command -v ag-mcp >/dev/null 2>&1; then
-      echo "[antigravity] Installed via pip --user. If 'ag-mcp' still missing from PATH, add: ${USER_BIN}" >&2
+      echo "[antigravity] Installed via pip --user. Add this to your shell rc to persist: export PATH=\"${USER_BIN}:\$PATH\"" >&2
       exit 0
     fi
   fi
@@ -32,12 +66,15 @@ fi
 cat >&2 <<EOF
 [antigravity] AUTO-INSTALL FAILED. Run ONE of these manually:
 
-  Option A (recommended):
+  Option A (recommended, requires pipx):
+    brew install pipx     # macOS
+    apt install pipx      # Debian/Ubuntu
+    pipx ensurepath
     pipx install "${PLUGIN_ROOT}/engine"
 
-  Option B:
+  Option B (no pipx):
     python3 -m pip install --user "${PLUGIN_ROOT}/engine" "${PLUGIN_ROOT}/cli"
 
-Then ensure the bin dir is on PATH and restart your Claude Code session.
+Then restart your Claude Code session.
 EOF
 exit 1


### PR DESCRIPTION
## Summary

When a Mac user without pipx ran \`/plugin install antigravity@antigravity\`, the SessionStart hook fell through to \`pip --user\`, succeeded at installing the package, but \`ag-mcp\` ended up under \`~/Library/Python/3.x/bin\` which isn't on PATH by default — so the next session said "Failed". Reproduced once already.

## What changed

- Hook now \`brew install pipx\` (macOS) or \`pip install --user pipx\` (cross-platform, no sudo) when pipx is missing.
- Calls \`pipx ensurepath\` and prepends \`~/.local/bin\` to PATH within the hook process so the \`pipx install\` that follows immediately finds the shim.
- The \`pip --user\` fallback also prepends USER_BIN to PATH for the verify step, and the success message is clearer about the persistent fix.
- Manual fallback message updated to mention package-manager install.

\`apt-get\`/\`dnf\` paths intentionally omitted because they need sudo (no TTY in hooks).

## Test plan

- [ ] Mac without pipx: install plugin → first session triggers brew → pipx → ag-mcp on PATH → exit 0
- [ ] Mac with pipx already: hook short-circuits at \`command -v ag-mcp\` (no-op)
- [ ] Linux (any) without pipx: installs pipx via pip --user → ag-mcp ends up in ~/.local/bin → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)