### PR TITLE
fix(plugin): cross-platform SessionStart hook (Windows support)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/install_engine.sh",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/install_engine.py\" || python \"${CLAUDE_PLUGIN_ROOT}/hooks/install_engine.py\"",
             "timeout": 300
           }
         ]

--- a/hooks/install_engine.bat
+++ b/hooks/install_engine.bat
@@ -1,31 +1,17 @@
 @echo off
-REM SessionStart hook (Windows). Mirrors install_engine.sh.
+REM Thin wrapper for manual invocation on Windows. Real install logic lives
+REM in install_engine.py so the Unix .sh wrapper and this share one source.
 setlocal
-
-set "PLUGIN_ROOT=%CLAUDE_PLUGIN_ROOT%"
-if "%PLUGIN_ROOT%"=="" set "PLUGIN_ROOT=%~dp0.."
-
-where ag-mcp >nul 2>&1
-if not errorlevel 1 exit /b 0
-
-echo [antigravity] ag-mcp not found. Attempting auto-install... 1>&2
-
-where pipx >nul 2>&1
-if not errorlevel 1 (
-    pipx install "%PLUGIN_ROOT%\engine" 1>&2 2>&1
-    where ag-mcp >nul 2>&1
-    if not errorlevel 1 exit /b 0
-)
-
 where python >nul 2>&1
 if not errorlevel 1 (
-    python -m pip install --user --quiet "%PLUGIN_ROOT%\engine" "%PLUGIN_ROOT%\cli" 1>&2 2>&1
-    where ag-mcp >nul 2>&1
-    if not errorlevel 1 exit /b 0
+    python "%~dp0install_engine.py"
+    exit /b %errorlevel%
 )
-
-echo [antigravity] AUTO-INSTALL FAILED. Run manually: 1>&2
-echo   pipx install "%PLUGIN_ROOT%\engine" 1>&2
-echo   - or - 1>&2
-echo   python -m pip install --user "%PLUGIN_ROOT%\engine" "%PLUGIN_ROOT%\cli" 1>&2
+where py >nul 2>&1
+if not errorlevel 1 (
+    py "%~dp0install_engine.py"
+    exit /b %errorlevel%
+)
+echo [antigravity] Python is required but neither 'python' nor 'py' was found on PATH. 1>&2
+echo Install Python 3.10+ from https://www.python.org/downloads/ and re-run. 1>&2
 exit /b 1

--- a/hooks/install_engine.py
+++ b/hooks/install_engine.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""SessionStart hook: ensure `ag-mcp` is on PATH.
+
+Single cross-platform installer for Claude Code's plugin SessionStart hook.
+Idempotent and silent on the happy path. All output goes to stderr (stdout
+on a hook is interpreted as injected context).
+
+Strategy:
+  1. If ag-mcp is already on PATH, exit 0.
+  2. Ensure pipx exists:
+       - macOS with Homebrew → `brew install pipx`
+       - Otherwise → `python -m pip install --user pipx`
+     Both paths require no sudo.
+  3. `pipx ensurepath` and prepend the pipx bin dir to PATH for the current
+     process so the next `pipx install` finds the freshly placed shim.
+  4. `pipx install <plugin_root>/engine`.
+  5. If pipx remains unavailable, fall back to `pip install --user`.
+  6. On total failure, print a clear manual-install message and exit 1.
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def has(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+def user_scripts_bin() -> Path | None:
+    """Resolve site.USER_BASE bin/Scripts dir from the current Python."""
+    try:
+        import site
+        base = Path(site.USER_BASE)
+    except Exception:
+        return None
+    candidate = base / ("Scripts" if os.name == "nt" else "bin")
+    return candidate if candidate.is_dir() else None
+
+
+def prepend_path(p: Path) -> None:
+    if not p.is_dir():
+        return
+    cur = os.environ.get("PATH", "")
+    parts = cur.split(os.pathsep)
+    if str(p) in parts:
+        return
+    os.environ["PATH"] = str(p) + os.pathsep + cur
+
+
+def run(cmd: list[str]) -> int:
+    try:
+        return subprocess.run(cmd, stderr=sys.stderr, stdout=sys.stderr).returncode
+    except FileNotFoundError:
+        return 127
+
+
+def ensure_pipx() -> bool:
+    """Install pipx if missing. Returns True if pipx is available afterwards."""
+    if has("pipx"):
+        return True
+
+    # macOS with Homebrew: cleanest path, no sudo.
+    if sys.platform == "darwin" and has("brew"):
+        log("[antigravity] Installing pipx via Homebrew...")
+        run(["brew", "install", "pipx"])
+
+    # Cross-platform fallback: pip install --user pipx.
+    if not has("pipx"):
+        py = sys.executable or ("python" if has("python") else "python3")
+        log(f"[antigravity] Installing pipx via pip --user ({py})...")
+        run([py, "-m", "pip", "install", "--user", "--quiet", "pipx"])
+        # User-base scripts/bin needs to be on PATH for `pipx` to be findable.
+        ub = user_scripts_bin()
+        if ub:
+            prepend_path(ub)
+
+    return has("pipx") or _has_pipx_module()
+
+
+def _has_pipx_module() -> bool:
+    """Some installs put pipx on PATH only after `ensurepath`. Check for the
+    module so we can invoke it via `python -m pipx` as a fallback."""
+    try:
+        subprocess.run(
+            [sys.executable or "python", "-m", "pipx", "--version"],
+            check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def pipx(args: list[str]) -> int:
+    if has("pipx"):
+        return run(["pipx", *args])
+    return run([sys.executable or "python", "-m", "pipx", *args])
+
+
+def main() -> int:
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT") or str(Path(__file__).resolve().parent.parent)
+    engine_dir = str(Path(plugin_root) / "engine")
+    cli_dir = str(Path(plugin_root) / "cli")
+
+    if has("ag-mcp"):
+        return 0
+
+    log("[antigravity] ag-mcp not found. Attempting auto-install...")
+
+    if ensure_pipx():
+        # After install or ensurepath, ~/.local/bin (POSIX) or %APPDATA%/Python/Scripts (Windows)
+        # may host the pipx shims. Prepend so the install runs and verifies in one process.
+        pipx(["ensurepath"])
+        local_bin = Path.home() / (".local/bin" if os.name != "nt" else "AppData/Roaming/Python/Scripts")
+        prepend_path(local_bin)
+        ub = user_scripts_bin()
+        if ub:
+            prepend_path(ub)
+
+        if pipx(["install", engine_dir]) == 0 and has("ag-mcp"):
+            log("[antigravity] Installed via pipx.")
+            return 0
+
+    # Fallback: pip --user
+    py = sys.executable or ("python" if has("python") else "python3")
+    log(f"[antigravity] Falling back to pip --user ({py})...")
+    if run([py, "-m", "pip", "install", "--user", "--quiet", engine_dir, cli_dir]) == 0:
+        ub = user_scripts_bin()
+        if ub:
+            prepend_path(ub)
+        if has("ag-mcp"):
+            log(f"[antigravity] Installed via pip --user. To persist on future shells, add this dir to PATH: {ub}")
+            return 0
+
+    log("")
+    log("[antigravity] AUTO-INSTALL FAILED. Run ONE of these manually:")
+    log("")
+    log("  Option A (recommended, requires pipx):")
+    log("    macOS:   brew install pipx && pipx ensurepath")
+    log("    Linux:   python3 -m pip install --user pipx && python3 -m pipx ensurepath")
+    log("    Windows: python -m pip install --user pipx && python -m pipx ensurepath")
+    log(f"    pipx install \"{engine_dir}\"")
+    log("")
+    log("  Option B (no pipx):")
+    log(f"    python -m pip install --user \"{engine_dir}\" \"{cli_dir}\"")
+    log("")
+    log("Then restart your Claude Code session.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hooks/install_engine.sh
+++ b/hooks/install_engine.sh
@@ -1,80 +1,8 @@
 #!/usr/bin/env bash
-# SessionStart hook: ensure ag-mcp is on PATH. Idempotent and silent on the happy path.
+# Thin wrapper for manual invocation. The real install logic lives in
+# `install_engine.py` so it can be reused by the Windows .bat wrapper and
+# the cross-platform hook command in `hooks.json`.
 set -u
-
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
-
-if command -v ag-mcp >/dev/null 2>&1; then
-  exit 0
-fi
-
-echo "[antigravity] ag-mcp not found. Attempting auto-install..." >&2
-
-# Step 1: ensure pipx exists.
-#
-# Hook runs without a TTY, so anything requiring `sudo` will hang. We pick the
-# safest available path:
-#   - macOS with Homebrew → `brew install pipx` (no sudo)
-#   - Anything else with python3 → `pip install --user pipx` (no sudo)
-# Linux users who prefer `apt`/`dnf` get a clear instruction in the final
-# fallback message below.
-if ! command -v pipx >/dev/null 2>&1; then
-  if command -v brew >/dev/null 2>&1; then
-    echo "[antigravity] Installing pipx via Homebrew..." >&2
-    brew install pipx 1>&2 2>&1 || true
-  elif command -v python3 >/dev/null 2>&1; then
-    echo "[antigravity] Installing pipx via pip --user..." >&2
-    python3 -m pip install --user --quiet pipx 1>&2 2>&1 || true
-    if [ -d "${HOME}/.local/bin" ]; then
-      export PATH="${HOME}/.local/bin:${PATH}"
-    fi
-  fi
-fi
-
-# Step 2: ensure pipx is on PATH (ensurepath is a no-op if already configured).
-if command -v pipx >/dev/null 2>&1; then
-  pipx ensurepath 1>&2 2>&1 || true
-  if [ -d "${HOME}/.local/bin" ]; then
-    export PATH="${HOME}/.local/bin:${PATH}"
-  fi
-fi
-
-# Step 3: install antigravity-engine via pipx.
-if command -v pipx >/dev/null 2>&1; then
-  if pipx install "${PLUGIN_ROOT}/engine" 1>&2 2>&1; then
-    if command -v ag-mcp >/dev/null 2>&1; then
-      echo "[antigravity] Installed via pipx." >&2
-      exit 0
-    fi
-  fi
-fi
-
-# Step 4: fallback to pip --user if pipx is still unavailable.
-if command -v python3 >/dev/null 2>&1; then
-  if python3 -m pip install --user --quiet "${PLUGIN_ROOT}/engine" "${PLUGIN_ROOT}/cli" 1>&2 2>&1; then
-    USER_BIN="$(python3 -c 'import site,os;print(os.path.join(site.USER_BASE,"bin"))' 2>/dev/null || true)"
-    if [ -n "${USER_BIN}" ] && [ -d "${USER_BIN}" ]; then
-      export PATH="${USER_BIN}:${PATH}"
-    fi
-    if [ -x "${USER_BIN}/ag-mcp" ] || command -v ag-mcp >/dev/null 2>&1; then
-      echo "[antigravity] Installed via pip --user. Add this to your shell rc to persist: export PATH=\"${USER_BIN}:\$PATH\"" >&2
-      exit 0
-    fi
-  fi
-fi
-
-cat >&2 <<EOF
-[antigravity] AUTO-INSTALL FAILED. Run ONE of these manually:
-
-  Option A (recommended, requires pipx):
-    brew install pipx     # macOS
-    apt install pipx      # Debian/Ubuntu
-    pipx ensurepath
-    pipx install "${PLUGIN_ROOT}/engine"
-
-  Option B (no pipx):
-    python3 -m pip install --user "${PLUGIN_ROOT}/engine" "${PLUGIN_ROOT}/cli"
-
-Then restart your Claude Code session.
-EOF
-exit 1
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec python3 "${DIR}/install_engine.py" 2>/dev/null \
+  || exec python "${DIR}/install_engine.py"


### PR DESCRIPTION
## Summary

The hooks.json only referenced \`install_engine.sh\`, so Windows users (no bash) hit a missing-file error. The \`install_engine.bat\` we shipped wasn't wired up.

## Fix

- New \`install_engine.py\` — single source of truth, cross-platform
- \`install_engine.{sh,bat}\` — thin wrappers for manual invocation
- \`hooks.json\` — \`python3 ... || python ...\` (portable across bash and cmd.exe)
- Python script handles Windows specifics: \`Scripts\\\` vs \`bin/\`, \`%APPDATA%\\Python\\Scripts\` for pipx shims

## Test plan

- [ ] macOS happy path (verified locally)
- [ ] macOS first-run with no pipx: brew install pipx → pipx install → ag-mcp on PATH
- [ ] Linux first-run: pip install --user pipx → pipx install → ag-mcp on PATH
- [ ] Windows first-run: pip install --user pipx → pipx install → ag-mcp.exe on PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)