### PR TITLE
feat(plugin): /antigravity:setup interactive .env writer

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,19 +1,21 @@
 # Installing the Antigravity plugin
 
-## Claude Code
-
-```
-/plugin marketplace add /absolute/path/to/antigravity-workspace-template
-/plugin install antigravity@antigravity
-```
-
-The first session after install runs `hooks/install_engine.sh`, which auto-installs the engine via `pipx` (preferred) or `pip --user`. If both fail, follow the printed manual command and restart the session.
-
-You can also add the marketplace directly from GitHub:
+## Claude Code (3 commands)
 
 ```
 /plugin marketplace add study8677/antigravity-workspace-template
 /plugin install antigravity@antigravity
+/antigravity:setup
+```
+
+1. **Marketplace add** — clones the plugin manifest into Claude Code's cache.
+2. **Install** — first session triggers `hooks/install_engine.py`, which auto-installs `ag-mcp` via `pipx` (preferred), `pip --user` fallback, or prints a manual command if both fail. Cross-platform (macOS / Linux / Windows).
+3. **Setup** — interactive: choose your LLM provider (OpenAI / DeepSeek / Groq / 阿里灵积 / NVIDIA / Ollama), paste your API key, writes a `.env` to the current project root and ensures it's git-ignored. **Restart Claude Code afterwards** so `ag-mcp` picks up the new env.
+
+You can also add the marketplace from a local checkout:
+
+```
+/plugin marketplace add /absolute/path/to/antigravity-workspace-template
 ```
 
 ## Codex CLI
@@ -34,16 +36,19 @@ codex plugin install antigravity
 
 ## Verifying
 
-- **Claude Code**: `/ag-ask "what does the engine do?"` should invoke `mcp__antigravity__ask_project`.
+- **Claude Code**: `/antigravity:ag-ask "what does the engine do?"` should invoke `mcp__antigravity__ask_project`.
 - **Codex CLI**: confirm the `antigravity` MCP server appears in your Codex MCP server list.
 
 ## Available slash commands (Claude Code)
 
+Slash commands are namespaced by plugin name — type `/antigravity:` to discover them.
+
 | Command | What it does |
 |---|---|
-| `/ag-ask <question>` | Routed Q&A on the current codebase |
-| `/ag-refresh [quick]` | Rebuild the project knowledge base |
-| `/ag-init <name>` | Scaffold a new multi-agent repo from this template |
+| `/antigravity:setup` | **First-time setup** — interactive `.env` writer (LLM provider + key + model) |
+| `/antigravity:ag-refresh [quick]` | Rebuild / incrementally update the project knowledge base |
+| `/antigravity:ag-ask <question>` | Routed Q&A on the current codebase |
+| `/antigravity:ag-init <name>` | Scaffold a new multi-agent repo from this template |
 
 ## Bundled MCP tools
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Architecture is **files + a live Q&A engine**, not plugins. Portable across any 
 # Claude Code (auto-installs the Python engine on first session via SessionStart hook)
 /plugin marketplace add study8677/antigravity-workspace-template
 /plugin install antigravity@antigravity
+/antigravity:setup            # interactive: pick LLM provider, paste API key, writes .env
 
 # Codex CLI (install the engine manually first; Codex hooks are not yet supported)
 pipx install "git+https://github.com/study8677/antigravity-workspace-template.git#subdirectory=engine"
@@ -79,7 +80,7 @@ codex plugin marketplace add study8677/antigravity-workspace-template
 codex plugin install antigravity
 ```
 
-After install you get `/ag-ask <question>`, `/ag-refresh`, `/ag-init <name>` slash commands plus the `antigravity` MCP server (`ask_project` + `refresh_project`). See [INSTALL.md](INSTALL.md) for details and troubleshooting.
+After install + setup you get `/antigravity:ag-ask <question>`, `/antigravity:ag-refresh`, `/antigravity:ag-init <name>` slash commands plus the `antigravity` MCP server (`ask_project` + `refresh_project`). See [INSTALL.md](INSTALL.md) for details and troubleshooting.
 
 **Option B — Manual install: engine + CLI via pip**
 ```bash

--- a/README_CN.md
+++ b/README_CN.md
@@ -72,6 +72,7 @@
 # Claude Code（首次会话由 SessionStart hook 自动安装 Python 引擎）
 /plugin marketplace add study8677/antigravity-workspace-template
 /plugin install antigravity@antigravity
+/antigravity:setup            # 交互式：选 LLM 提供商、贴 API key，自动写 .env
 
 # Codex CLI（需手动先装引擎；Codex 暂不支持自动 hook）
 pipx install "git+https://github.com/study8677/antigravity-workspace-template.git#subdirectory=engine"
@@ -79,7 +80,7 @@ codex plugin marketplace add study8677/antigravity-workspace-template
 codex plugin install antigravity
 ```
 
-安装后即可使用 `/ag-ask <问题>`、`/ag-refresh`、`/ag-init <名字>` 斜杠命令，以及 `antigravity` MCP 服务（`ask_project` + `refresh_project`）。详见 [INSTALL.md](INSTALL.md)。
+安装并 setup 后即可使用 `/antigravity:ag-ask <问题>`、`/antigravity:ag-refresh`、`/antigravity:ag-init <名字>` 斜杠命令，以及 `antigravity` MCP 服务（`ask_project` + `refresh_project`）。详见 [INSTALL.md](INSTALL.md)。
 
 **方案 B —— 手动安装：通过 pip 安装引擎 + CLI**
 ```bash

--- a/README_ES.md
+++ b/README_ES.md
@@ -72,6 +72,7 @@ La arquitectura son **archivos + un motor Q&A en vivo**, no plugins. Portable en
 # Claude Code (auto-instala el motor Python en la primera sesión vía SessionStart hook)
 /plugin marketplace add study8677/antigravity-workspace-template
 /plugin install antigravity@antigravity
+/antigravity:setup            # interactivo: elige proveedor LLM, pega API key, escribe .env
 
 # Codex CLI (instala el motor manualmente primero; los hooks de Codex aún no son soportados)
 pipx install "git+https://github.com/study8677/antigravity-workspace-template.git#subdirectory=engine"
@@ -79,7 +80,7 @@ codex plugin marketplace add study8677/antigravity-workspace-template
 codex plugin install antigravity
 ```
 
-Después de instalar dispondrás de los comandos slash `/ag-ask <pregunta>`, `/ag-refresh`, `/ag-init <nombre>`, y del servidor MCP `antigravity` (`ask_project` + `refresh_project`). Ver [INSTALL.md](INSTALL.md) para detalles y solución de problemas.
+Después de instalar y configurar dispondrás de los comandos slash `/antigravity:ag-ask <pregunta>`, `/antigravity:ag-refresh`, `/antigravity:ag-init <nombre>`, y del servidor MCP `antigravity` (`ask_project` + `refresh_project`). Ver [INSTALL.md](INSTALL.md) para detalles y solución de problemas.
 
 **Opción B — Instalación manual: motor + CLI vía pip**
 ```bash

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,0 +1,69 @@
+---
+description: First-time setup. Configure the LLM API key Antigravity uses to read and analyze your codebase. Run this once per project before /antigravity:ag-refresh.
+---
+
+You are running first-time setup for the Antigravity plugin. The user just installed the plugin and needs an LLM API key configured before `/antigravity:ag-refresh` and `/antigravity:ag-ask` will work. Goal: write a `.env` file at the current workspace root.
+
+## Step 1 — Detect existing config
+
+Read `.env` at the workspace root if it exists. If `OPENAI_API_KEY` is already set, ask the user whether to overwrite. If they say no, confirm "already configured" and stop.
+
+## Step 2 — Ask which LLM provider (use AskUserQuestion)
+
+Present these options:
+
+- **OpenAI** — gpt-4o-mini / gpt-4o
+- **DeepSeek** — cheap, strong on code
+- **Groq** — fast, free tier
+- **阿里灵积 (DashScope)** — qwen 系列
+- **NVIDIA NIM** — generous free tier
+- **Ollama 本地** — no key needed, runs locally
+- **其他 OpenAI 兼容端点** — custom URL
+
+## Step 3 — Collect URL / key / model
+
+Use this table to set the URL and suggest a model based on the provider:
+
+| Provider | `OPENAI_BASE_URL` | Suggested `OPENAI_MODEL` |
+|---|---|---|
+| OpenAI | `https://api.openai.com/v1` | `gpt-4o-mini` |
+| DeepSeek | `https://api.deepseek.com/v1` | `deepseek-chat` |
+| Groq | `https://api.groq.com/openai/v1` | `llama-3.3-70b-versatile` |
+| 阿里灵积 | `https://dashscope.aliyuncs.com/compatible-mode/v1` | `qwen-max` |
+| NVIDIA NIM | `https://integrate.api.nvidia.com/v1` | `meta/llama-3.3-70b-instruct` |
+| Ollama 本地 | `http://localhost:11434/v1` | `llama3.2` (key can be `ollama`) |
+| 其他 | ask the user | ask the user |
+
+For non-Ollama providers ask the user to paste their key. For Ollama use `OPENAI_API_KEY=ollama` (the engine requires the field to be non-empty).
+
+## Step 4 — Write `.env`
+
+Write to `<workspace>/.env`:
+
+```
+OPENAI_BASE_URL=<chosen URL>
+OPENAI_API_KEY=<the key, or "ollama">
+OPENAI_MODEL=<chosen model>
+AG_ASK_TIMEOUT_SECONDS=120
+```
+
+If `.env` already existed and the user opted to overwrite, replace only the four keys above; preserve any other lines.
+
+## Step 5 — Ensure `.env` is git-ignored
+
+Check `<workspace>/.gitignore`. If `.env` is not listed (and there is no globbing rule that already covers it), append `.env` on a new line. If `.gitignore` doesn't exist, create one with `.env`.
+
+## Step 6 — Tell the user next steps
+
+Print exactly:
+
+```
+✅ Antigravity is configured for this project.
+
+Next:
+  1. Restart Claude Code (Ctrl+C twice, then re-run claude) so ag-mcp picks up the new .env.
+  2. /antigravity:ag-refresh        — build the knowledge base (one-time, a few minutes for small repos)
+  3. /antigravity:ag-ask <question> — ask anything about the codebase
+```
+
+Do NOT call `mcp__antigravity__refresh_project` from this command — the engine subprocess that's running right now still has the old (empty) env. The user must restart Claude Code first.


### PR DESCRIPTION
## Summary

Closes the UX gap where a new user installing the plugin had no clear path to configure the LLM API key. They'd run \`/ag-refresh\` and hit a cryptic failure.

## What's added

- \`commands/setup.md\` — slash command that interactively picks an LLM provider, collects the key, writes \`.env\` at the workspace root, and ensures \`.env\` is in \`.gitignore\`
- Updated \`INSTALL.md\` to feature the canonical 3-command install path:
  \`\`\`
  /plugin marketplace add study8677/antigravity-workspace-template
  /plugin install antigravity@antigravity
  /antigravity:setup
  \`\`\`
- Updated README / README_CN / README_ES Option A to mention setup
- Slash command names referenced with namespace prefix (\`/antigravity:\`) consistently

## Provider menu

OpenAI · DeepSeek · Groq · 阿里灵积 · NVIDIA NIM · Ollama · custom

## Test plan

- [ ] After \`/plugin install antigravity@antigravity\`, \`/antigravity:setup\` is discoverable in the slash command list
- [ ] Running it writes a valid \`.env\` to the current project
- [ ] If \`.env\` already has \`OPENAI_API_KEY\`, command asks before overwriting
- [ ] \`.env\` gets appended to \`.gitignore\` if missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)