### PR TITLE
fix(plugin): hook short-circuits when ag-mcp is on user PATH

### DIFF
--- a/hooks/install_engine.py
+++ b/hooks/install_engine.py
@@ -109,6 +109,17 @@ def main() -> int:
     engine_dir = str(Path(plugin_root) / "engine")
     cli_dir = str(Path(plugin_root) / "cli")
 
+    # Claude Code starts hooks with a minimal PATH that often excludes user bin
+    # dirs, so an already-installed ag-mcp can look "missing". Prepend the
+    # common user-level shim locations BEFORE the fast-path check so a previous
+    # successful install short-circuits cleanly.
+    prepend_path(Path.home() / ".local" / "bin")
+    ub = user_scripts_bin()
+    if ub:
+        prepend_path(ub)
+    if os.name == "nt":
+        prepend_path(Path.home() / "AppData" / "Roaming" / "Python" / "Scripts")
+
     if has("ag-mcp"):
         return 0
 


### PR DESCRIPTION
## Bug

After a successful first install, every subsequent Claude Code session printed:

\`\`\`
[antigravity] ag-mcp not found. Attempting auto-install...
\`\`\`

…and then re-ran pipx install, even though ag-mcp was already on the user's PATH.

## Cause

Claude Code starts SessionStart hooks with a minimal PATH (\`/usr/bin:/bin\` on macOS, similar on Linux). User-pip / pipx shim dirs aren't included, so \`shutil.which("ag-mcp")\` returned None.

## Fix

Prepend common user shim dirs to PATH **before** the fast-path \`has("ag-mcp")\` check:

- POSIX: \`~/.local/bin\`, \`site.USER_BASE/bin\`
- Windows: \`%APPDATA%\\Roaming\\Python\\Scripts\`, \`site.USER_BASE\\Scripts\`

## Verification

\`\`\`
env -i HOME="$HOME" PATH="/usr/bin:/bin" python3 hooks/install_engine.py
# exit=0, no stderr  ← was previously noisy + re-installed
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)