### PR TITLE
fix(plugin+engine): MCP server crashed when ${CLAUDE_PROJECT_DIR} wasn't substituted

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,8 +15,10 @@
   "mcpServers": {
     "antigravity": {
       "command": "ag-mcp",
-      "args": ["--workspace", "${CLAUDE_PROJECT_DIR}"],
-      "env": {}
+      "args": [],
+      "env": {
+        "WORKSPACE_PATH": "${CLAUDE_PROJECT_DIR}"
+      }
     }
   }
 }

--- a/engine/antigravity_engine/hub/mcp_server.py
+++ b/engine/antigravity_engine/hub/mcp_server.py
@@ -29,11 +29,19 @@ from pathlib import Path
 
 
 def _resolve_workspace(workspace: str | None) -> Path:
-    """Resolve workspace path from argument or environment."""
-    if workspace:
+    """Resolve workspace path from argument or environment.
+
+    Treats values containing un-expanded `${...}` placeholders (which happen
+    when an MCP host's variable substitution doesn't cover a particular field)
+    as if they were not provided, falling through to the next source.
+    """
+    def _usable(v: str | None) -> bool:
+        return bool(v) and "${" not in v
+
+    if _usable(workspace):
         return Path(workspace).resolve()
     env = os.environ.get("WORKSPACE_PATH", "")
-    if env:
+    if _usable(env):
         return Path(env).resolve()
     return Path.cwd()
 


### PR DESCRIPTION
## Bug

User's Claude Code reports \`The plugin:antigravity:antigravity MCP server failed to connect\` after a clean install. Reproduced locally — ag-mcp received literal string \`\${CLAUDE_PROJECT_DIR}\` as --workspace and exited:

\`\`\`
Error: workspace does not exist: /…/antigravity-workspace-template/\${CLAUDE_PROJECT_DIR}
\`\`\`

The variable wasn't substituted by Claude Code in plugin.json's \`mcpServers.args\` field.

## Fix

1. **plugin.json** — move the workspace handoff from \`args\` to \`env\` (\`WORKSPACE_PATH=\${CLAUDE_PROJECT_DIR}\`). Args is empty.
2. **engine \`_resolve_workspace\`** — treat values containing un-expanded \`\${...}\` placeholders as missing, falling through to env / cwd. Defensive against future host substitution gaps.

After the fix, ag-mcp resolves workspace from (in order): env var → cwd. Both work with Claude Code, including hosts that don't substitute variables in mcpServers.

## Test plan

- [ ] Reinstall plugin in user's Claude Code → MCP server connects on next session
- [ ] \`/antigravity:ag-refresh\` invokable
- [ ] Manual: \`ag-mcp --workspace '\${CLAUDE_PROJECT_DIR}'\` no longer crashes (falls back to cwd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)