### PR TITLE
feat(engine): use MCP roots protocol to discover workspace from client

### DIFF
--- a/engine/antigravity_engine/config.py
+++ b/engine/antigravity_engine/config.py
@@ -149,10 +149,17 @@ _settings: Settings | None = None
 
 
 def get_settings() -> Settings:
-    """Return the global Settings instance, creating it on first call."""
+    """Return the global Settings instance, creating it on first call.
+
+    Resolves the .env path from the *current* value of WORKSPACE_PATH
+    rather than the value frozen at class-definition time. This lets
+    runtime workspace upgrades (e.g. via MCP roots protocol) take effect
+    after `reset_settings()`.
+    """
     global _settings
     if _settings is None:
-        _settings = Settings()
+        env_path = Path(os.environ.get("WORKSPACE_PATH", str(Path.cwd()))) / ".env"
+        _settings = Settings(_env_file=str(env_path))
     return _settings
 
 

--- a/engine/antigravity_engine/hub/mcp_server.py
+++ b/engine/antigravity_engine/hub/mcp_server.py
@@ -67,13 +67,85 @@ def _resolve_workspace(workspace: str | None) -> Path:
     return cwd
 
 
+# Active workspace is module-level so MCP roots can upgrade it on the first
+# tool call after the protocol handshake completes. Initialized by serve().
+_active_workspace: Path | None = None
+_roots_attempted = False
+
+
+def _root_uri_to_path(uri: str) -> Path | None:
+    """Convert an MCP file:// root URI to a filesystem Path."""
+    from urllib.parse import unquote, urlparse
+
+    parsed = urlparse(uri)
+    if parsed.scheme != "file":
+        return None
+    raw = unquote(parsed.path or "")
+    if not raw:
+        return None
+    return Path(raw).resolve()
+
+
+async def _maybe_upgrade_via_roots(ctx) -> None:
+    """If the MCP client supports the `roots` protocol, prefer its root.
+
+    MCP clients (Claude Code, Cursor, etc.) typically advertise the open
+    project as a workspace root. Asking the client directly is the most
+    reliable workspace source — better than args (host may not substitute
+    variables), better than env (same), better than cwd-scan (may pick a
+    nested git repo or miss entirely).
+
+    Idempotent: only attempts once per process. On success, updates
+    `_active_workspace`, sets WORKSPACE_PATH env var, and resets the
+    cached Settings so the new project's `.env` is read on next access.
+    """
+    global _active_workspace, _roots_attempted
+    if _roots_attempted:
+        return
+    _roots_attempted = True
+
+    try:
+        result = await ctx.request_context.session.list_roots()
+    except Exception as exc:  # noqa: BLE001 — client may not support roots
+        print(f"[ag-mcp] MCP roots/list unavailable ({exc.__class__.__name__}): keeping workspace = {_active_workspace}", file=sys.stderr)
+        return
+
+    if not result.roots:
+        print(f"[ag-mcp] MCP roots/list returned empty list: keeping workspace = {_active_workspace}", file=sys.stderr)
+        return
+
+    new_workspace = _root_uri_to_path(str(result.roots[0].uri))
+    if new_workspace is None or not new_workspace.exists():
+        print(f"[ag-mcp] MCP roots/list returned unusable URI {result.roots[0].uri!r}: keeping workspace = {_active_workspace}", file=sys.stderr)
+        return
+
+    if new_workspace == _active_workspace:
+        print(f"[ag-mcp] MCP roots confirmed workspace = {_active_workspace}", file=sys.stderr)
+        return
+
+    print(f"[ag-mcp] upgrading workspace via MCP roots: {_active_workspace} → {new_workspace}", file=sys.stderr)
+    _active_workspace = new_workspace
+    os.environ["WORKSPACE_PATH"] = str(new_workspace)
+    try:
+        from antigravity_engine.config import reset_settings
+
+        reset_settings()
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def serve(workspace: Path) -> None:
     """Start the MCP server on stdio.
 
     Args:
-        workspace: Absolute path to the project root.
+        workspace: Initial workspace guess from CLI/env/cwd-scan. Will be
+            upgraded to the MCP client's reported root on the first tool call
+            if the client supports the `roots` protocol.
     """
-    from mcp.server.fastmcp import FastMCP
+    global _active_workspace
+    _active_workspace = workspace
+
+    from mcp.server.fastmcp import Context, FastMCP
 
     mcp = FastMCP(
         "Antigravity Knowledge Hub",
@@ -86,7 +158,7 @@ def serve(workspace: Path) -> None:
     )
 
     @mcp.tool()
-    async def ask_project(question: str) -> str:
+    async def ask_project(question: str, ctx: Context) -> str:
         """Answer a question about the project using the knowledge hub.
 
         Searches the codebase, reads actual source files, checks git history,
@@ -102,15 +174,16 @@ def serve(workspace: Path) -> None:
         Returns:
             Grounded answer with file paths, line numbers, and context.
         """
+        await _maybe_upgrade_via_roots(ctx)
         from antigravity_engine.hub.pipeline import ask_pipeline
 
         try:
-            return await ask_pipeline(workspace, question)
+            return await ask_pipeline(_active_workspace, question)
         except Exception as exc:  # noqa: BLE001
             return f"Error: {exc}"
 
     @mcp.tool()
-    async def refresh_project(quick: bool = False) -> str:
+    async def refresh_project(quick: bool = False, ctx: Context = None) -> str:
         """Rebuild the project knowledge base (.antigravity/conventions.md and structure.md).
 
         Run this after significant code changes to keep the knowledge base
@@ -124,11 +197,13 @@ def serve(workspace: Path) -> None:
         Returns:
             Confirmation message with updated file paths.
         """
+        if ctx is not None:
+            await _maybe_upgrade_via_roots(ctx)
         from antigravity_engine.hub.pipeline import refresh_pipeline
 
         try:
-            await refresh_pipeline(workspace, quick=quick)
-            ag_dir = workspace / ".antigravity"
+            await refresh_pipeline(_active_workspace, quick=quick)
+            ag_dir = _active_workspace / ".antigravity"
             return (
                 f"Knowledge base updated:\n"
                 f"  {ag_dir / 'conventions.md'}\n"


### PR DESCRIPTION
## Why

Previous workspace resolution chain (args → env → cwd-scan) is fragile:

- args: needs the MCP host to substitute \`\${CLAUDE_PROJECT_DIR}\` (Claude Code doesn't, in mcpServers args)
- env: same substitution problem
- cwd-scan: picks the wrong root in monorepos with nested .git, fails in scratch dirs

The MCP protocol defines \`roots\` exactly for this. The client tells the server which directories it's working on. Asking the client is **always more reliable** than any host-dependent guess.

## Behaviour

1. \`main()\` still resolves an initial workspace via the legacy chain so direct \`ag-mcp --workspace ...\` invocation still works.
2. On the first \`ask_project\` / \`refresh_project\` call, ag-mcp issues \`roots/list\` to the client.
3. If the client returns a root → upgrade workspace, reset Settings, log to stderr.
4. If the client doesn't support roots or returns empty → keep initial workspace.

## Test

- [x] Root URI parser handles file:// correctly, rejects other schemes
- [x] Graceful fallback when client doesn't support roots
- [ ] Real Claude Code session: \`/antigravity:ag-refresh\` from agent-mailer → roots upgrade fires → correct .env read

User update path:
\`\`\`
pipx install --force "git+https://github.com/study8677/antigravity-workspace-template.git#subdirectory=engine"
# restart Claude Code
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)