### PR TITLE
fix(scanner): support Python 3.10 by falling back to tomli

### DIFF
--- a/engine/antigravity_engine/hub/scanner.py
+++ b/engine/antigravity_engine/hub/scanner.py
@@ -375,9 +375,12 @@ def _read_entry_points(root: Path, config_contents: dict[str, str]) -> dict[str,
     pyproject_text = config_contents.get("pyproject.toml", "")
     if pyproject_text:
         try:
-            import tomllib
+            import tomllib  # type: ignore[import-not-found]
         except ModuleNotFoundError:
-            tomllib = None  # type: ignore[assignment]
+            try:
+                import tomli as tomllib  # type: ignore[import-not-found, no-redef]
+            except ModuleNotFoundError:
+                tomllib = None  # type: ignore[assignment]
         if tomllib is not None:
             try:
                 data = tomllib.loads(pyproject_text)

--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "requests>=2.33.0,<3",
     "mcp[cli]>=1.0.0,<2",
     "openai-agents[litellm]>=0.12,<0.15",
+    "tomli>=2.0,<3; python_version < \"3.11\"",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- `_read_entry_points` in `engine/antigravity_engine/hub/scanner.py` imports stdlib `tomllib`, which only exists on Python 3.11+. On 3.10 the `ModuleNotFoundError` was silently swallowed and entry points were never detected.
- This is the root cause of `engine-test (3.10)` being red on `main` (`test_full_scan_detects_entry_points_from_pyproject` fails: `assert 'ag_cli/cli.py' in {}`). It is independent of #74 — the Dependabot openai-agents bump fails CI only because this pre-existing 3.10 bug blocks merge.
- Fall back to the `tomli` backport on 3.10 and add a conditional dependency in `engine/pyproject.toml`.

## Test plan
- [x] `pytest engine/tests/test_hub_scanner.py` passes under Python 3.10 locally (28/28).
- [ ] CI `engine-test (3.10)` turns green.
- [ ] After merge, rebase Dependabot PR #74 and merge.