### PR TITLE
build(deps): update openai-agents requirement to >=0.12,<0.18

### DIFF
--- a/engine/pyproject.toml
+++ b/engine/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "python-dotenv>=1.0,<2",
     "requests>=2.33.0,<3",
     "mcp[cli]>=1.0.0,<2",
-    "openai-agents[litellm]>=0.12,<0.15",
+    "openai-agents[litellm]>=0.12,<0.18",
     "tomli>=2.0,<3; python_version < \"3.11\"",
 ]
 


### PR DESCRIPTION
## Summary
- Manual replay of Dependabot PR #74 (`openai-agents` `<0.15` -> `<0.18`).
- Dependabot's auto-rebase conflicted with #77 (scanner 3.10 fix) because both PRs touched `engine/pyproject.toml`.
- This PR carries the same single-line dependency bump on top of fresh `main`.
- Supersedes #74.

## Test plan
- [ ] CI green on all 8 checks (3.10/3.11/3.12 engine + cli, contract, docker).