### PR TITLE
feat(hub): 新增 TypeScript/JavaScript 语义适配器

### DIFF
--- a/docs/hub_semantic_adapters.md
+++ b/docs/hub_semantic_adapters.md
@@ -66,6 +66,37 @@ The core IR is language-neutral:
 - Go-specific signature summaries for group splitting
 - nested `go.mod` module-root normalization
 
+### TypeScript / JavaScript
+
+`language_adapters/typescript_adapter.py` supports `.ts`, `.tsx`, `.js`, and
+`.jsx` files. It uses a lightweight line-oriented parser rather than a full
+TypeScript compiler parser.
+
+Import extraction covers:
+
+- `import ... from "module"`
+- side-effect imports such as `import "module"`
+- dynamic imports such as `import("module")`
+- CommonJS `require("module")`
+- re-exports such as `export ... from "module"`
+
+Relative imports are normalized to stable extensionless repository module keys
+such as `src/components/button`. Files also provide their own extensionless
+module key, plus a `src/`-stripped alias for grouping convenience. `index.ts`
+and `index.js` files additionally provide the parent directory module key.
+
+Top-level symbol extraction covers:
+
+- `function` and `async function`
+- `class`
+- `interface`
+- `type`
+- `enum`
+- exported `const`, `let`, and `var` declarations
+
+Test detection covers `*.test.ts`, `*.spec.ts`, `*.test.tsx`, `*.spec.tsx`,
+and the same `.js`/`.jsx` variants, plus files under `__tests__/`.
+
 ### Fallback
 
 `language_adapters/generic_adapter.py` is used when a file extension is
@@ -123,5 +154,8 @@ To add TypeScript, Rust, or Java:
 - Adapters are intentionally lightweight and top-level only.
 - No full type resolution or cross-package symbol resolution is attempted.
 - Generic fallback summaries are coarse by design.
+- The TypeScript/JavaScript adapter is regex/line based. It does not evaluate
+  path aliases from `tsconfig.json`, resolve package exports, infer React
+  components, or parse nested/local declarations.
 - The current Go adapter assumes import paths are resolved from the nearest
   `go.mod`; multi-module workspaces beyond that are not deeply modeled.

--- a/engine/antigravity_engine/hub/language_adapters/__init__.py
+++ b/engine/antigravity_engine/hub/language_adapters/__init__.py
@@ -13,12 +13,14 @@ from antigravity_engine.hub.language_adapters.base import (
 from antigravity_engine.hub.language_adapters.generic_adapter import GenericLanguageAdapter
 from antigravity_engine.hub.language_adapters.go_adapter import GoLanguageAdapter
 from antigravity_engine.hub.language_adapters.python_adapter import PythonLanguageAdapter
+from antigravity_engine.hub.language_adapters.typescript_adapter import TypeScriptLanguageAdapter
 
 
 _GENERIC_ADAPTER = GenericLanguageAdapter()
 _ADAPTERS: tuple[LanguageAdapter, ...] = (
     PythonLanguageAdapter(),
     GoLanguageAdapter(),
+    TypeScriptLanguageAdapter(),
 )
 _ADAPTER_BY_SUFFIX = {
     suffix: adapter

--- a/engine/antigravity_engine/hub/language_adapters/typescript_adapter.py
+++ b/engine/antigravity_engine/hub/language_adapters/typescript_adapter.py
@@ -108,6 +108,7 @@ class TypeScriptLanguageAdapter:
     def _extract_import_refs(self, content: str, rel_path: str) -> list[_ImportRef]:
         """Extract ES module, dynamic import, require, and re-export specs."""
         searchable = self._strip_comments(content)
+        code_mask = self._mask_non_code(content)
         matches: list[tuple[int, str]] = []
         for pattern in (
             _IMPORT_FROM_RE,
@@ -117,6 +118,8 @@ class TypeScriptLanguageAdapter:
             _EXPORT_FROM_RE,
         ):
             for match in pattern.finditer(searchable):
+                if not self._match_starts_in_code(code_mask, match.start()):
+                    continue
                 matches.append((match.start(), match.group(1)))
 
         refs: list[_ImportRef] = []
@@ -505,6 +508,10 @@ class TypeScriptLanguageAdapter:
             if value.endswith(suffix):
                 return value[: -len(suffix)]
         return value
+
+    def _match_starts_in_code(self, masked_content: str, start: int) -> bool:
+        """Return whether a regex import match starts outside strings/comments."""
+        return start < len(masked_content) and not masked_content[start].isspace()
 
     def _strip_comments(self, content: str) -> str:
         """Remove line and block comments while preserving string literals."""

--- a/engine/antigravity_engine/hub/language_adapters/typescript_adapter.py
+++ b/engine/antigravity_engine/hub/language_adapters/typescript_adapter.py
@@ -1,0 +1,606 @@
+"""TypeScript and JavaScript semantic adapter for hub graphing and grouping."""
+from __future__ import annotations
+
+import posixpath
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from antigravity_engine.hub.language_adapters.base import FileSemantics, SymbolDef
+
+
+_IMPORT_FROM_RE = re.compile(
+    r"\bimport\s+(?:type\s+)?(?:[^;'\"`]|\"[^\"]*\"|'[^']*'|`[^`]*`)*?"
+    r"\s+from\s*['\"]([^'\"]+)['\"]",
+    re.MULTILINE,
+)
+_IMPORT_SIDE_EFFECT_RE = re.compile(
+    r"^\s*import\s*['\"]([^'\"]+)['\"]",
+    re.MULTILINE,
+)
+_DYNAMIC_IMPORT_RE = re.compile(r"\bimport\s*\(\s*['\"]([^'\"]+)['\"]\s*\)")
+_REQUIRE_RE = re.compile(r"\brequire\s*\(\s*['\"]([^'\"]+)['\"]\s*\)")
+_EXPORT_FROM_RE = re.compile(
+    r"\bexport\s+(?:type\s+)?(?:[^;'\"`]|\"[^\"]*\"|'[^']*'|`[^`]*`)*?"
+    r"\s+from\s*['\"]([^'\"]+)['\"]",
+    re.MULTILINE,
+)
+_IDENTIFIER_RE = r"[A-Za-z_$][A-Za-z0-9_$]*"
+_TEST_FILE_RE = re.compile(r"\.(?:test|spec)\.(?:ts|tsx|js|jsx)$")
+_MODULE_SUFFIXES = (".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs")
+_LANGUAGE_BY_SUFFIX = {
+    ".ts": "TypeScript",
+    ".tsx": "TypeScript (React)",
+    ".js": "JavaScript",
+    ".jsx": "JavaScript (React)",
+}
+
+
+@dataclass(frozen=True)
+class _ImportRef:
+    """Normalized import reference plus whether it came from a relative spec."""
+
+    raw: str
+    normalized: str
+    is_relative: bool
+
+
+class TypeScriptLanguageAdapter:
+    """Analyze TS/JS files with a lightweight deterministic parser."""
+
+    name = "typescript"
+    supported_suffixes: frozenset[str] = frozenset({".ts", ".tsx", ".js", ".jsx"})
+
+    def analyze(
+        self,
+        workspace: Path,
+        abs_path: Path,
+        rel_path: str,
+        content: str,
+    ) -> FileSemantics:
+        """Analyze a TypeScript or JavaScript file into shared semantics.
+
+        Args:
+            workspace: Workspace root directory.
+            abs_path: Absolute file path.
+            rel_path: Workspace-relative path.
+            content: Decoded file contents.
+
+        Returns:
+            Extracted TS/JS semantics for graph construction and grouping.
+        """
+        del workspace
+        language = _LANGUAGE_BY_SUFFIX.get(abs_path.suffix.lower(), "JavaScript")
+        module_name = self._module_name(rel_path)
+        package_name = self._package_name(rel_path)
+        provided_modules = self._provided_modules(module_name)
+        import_refs = self._extract_import_refs(content, rel_path)
+        imports = self._dedupe([ref.normalized for ref in import_refs])
+        symbols = self._extract_symbols(content)
+        entrypoints = [symbol.name for symbol in symbols if symbol.is_entrypoint]
+        is_test_file = self._is_test_file(rel_path)
+        test_targets = self._test_targets(rel_path, import_refs) if is_test_file else []
+        signature_summary = self._build_signature_summary(
+            rel_path=rel_path,
+            module_name=module_name,
+            package_name=package_name,
+            imports=imports,
+            symbols=symbols,
+            is_test_file=is_test_file,
+        )
+
+        return FileSemantics(
+            rel_path=rel_path,
+            language=language,
+            adapter_name=self.name,
+            package_name=package_name,
+            package_identity=module_name,
+            module_name=module_name,
+            provided_modules=provided_modules,
+            imports=imports,
+            symbols=symbols,
+            entrypoints=entrypoints,
+            is_test_file=is_test_file,
+            test_targets=test_targets,
+            signature_summary=signature_summary,
+        )
+
+    def _extract_import_refs(self, content: str, rel_path: str) -> list[_ImportRef]:
+        """Extract ES module, dynamic import, require, and re-export specs."""
+        searchable = self._strip_comments(content)
+        matches: list[tuple[int, str]] = []
+        for pattern in (
+            _IMPORT_FROM_RE,
+            _IMPORT_SIDE_EFFECT_RE,
+            _DYNAMIC_IMPORT_RE,
+            _REQUIRE_RE,
+            _EXPORT_FROM_RE,
+        ):
+            for match in pattern.finditer(searchable):
+                matches.append((match.start(), match.group(1)))
+
+        refs: list[_ImportRef] = []
+        for _, raw in sorted(matches, key=lambda item: item[0]):
+            normalized = self._normalize_import(raw, rel_path)
+            refs.append(
+                _ImportRef(
+                    raw=raw,
+                    normalized=normalized,
+                    is_relative=raw.startswith("."),
+                )
+            )
+        return self._dedupe_import_refs(refs)
+
+    def _extract_symbols(self, content: str) -> list[SymbolDef]:
+        """Extract top-level TS/JS declarations without a full parser."""
+        symbols: list[SymbolDef] = []
+        lines = content.splitlines()
+        masked_lines = self._mask_non_code(content).splitlines()
+        brace_depth = 0
+        has_main_guard = self._has_main_guard(content)
+
+        for index, masked_line in enumerate(masked_lines):
+            original = lines[index] if index < len(lines) else ""
+            stripped = original.strip()
+            depth_before = brace_depth
+
+            if depth_before == 0 and stripped and not stripped.startswith(("//", "*")):
+                declaration = self._collect_declaration(lines, index)
+                symbol = self._parse_top_level_symbol(
+                    declaration=declaration,
+                    line=index + 1,
+                    has_main_guard=has_main_guard,
+                )
+                if symbol is not None:
+                    symbols.extend(symbol)
+
+            brace_depth = max(
+                0,
+                brace_depth + masked_line.count("{") - masked_line.count("}"),
+            )
+
+        return symbols
+
+    def _parse_top_level_symbol(
+        self,
+        *,
+        declaration: str,
+        line: int,
+        has_main_guard: bool,
+    ) -> list[SymbolDef] | None:
+        """Parse a single top-level declaration into zero or more symbols."""
+        signature = declaration.strip()
+        normalized = self._normalize_spaces(signature)
+        if not normalized:
+            return None
+
+        subject, exported = self._strip_modifiers(normalized)
+
+        if subject.startswith("const enum "):
+            enum_match = re.match(rf"const\s+enum\s+(?P<name>{_IDENTIFIER_RE})\b", subject)
+            if enum_match:
+                return [
+                    SymbolDef(
+                        name=enum_match.group("name"),
+                        kind="enum",
+                        qualified_name=enum_match.group("name"),
+                        line=line,
+                        signature=signature,
+                    )
+                ]
+
+        function_match = re.match(
+            rf"(?:async\s+)?function\s+(?P<name>{_IDENTIFIER_RE})\s*(?:<|\()",
+            subject,
+        )
+        if function_match:
+            name = function_match.group("name")
+            is_entrypoint = name == "main" and has_main_guard
+            return [
+                SymbolDef(
+                    name=name,
+                    kind="function",
+                    qualified_name=name,
+                    line=line,
+                    signature=signature,
+                    is_entrypoint=is_entrypoint,
+                )
+            ]
+
+        class_match = re.match(
+            rf"class\s+(?P<name>{_IDENTIFIER_RE})(?:\s*<[^>]+>)?"
+            r"(?:\s+extends\s+(?P<bases>[^{]+))?",
+            subject,
+        )
+        if class_match:
+            name = class_match.group("name")
+            return [
+                SymbolDef(
+                    name=name,
+                    kind="class",
+                    qualified_name=name,
+                    line=line,
+                    signature=signature,
+                    bases=self._parse_bases(class_match.group("bases")),
+                )
+            ]
+
+        interface_match = re.match(
+            rf"interface\s+(?P<name>{_IDENTIFIER_RE})(?:\s*<[^>]+>)?"
+            r"(?:\s+extends\s+(?P<bases>[^{]+))?",
+            subject,
+        )
+        if interface_match:
+            name = interface_match.group("name")
+            return [
+                SymbolDef(
+                    name=name,
+                    kind="interface",
+                    qualified_name=name,
+                    line=line,
+                    signature=signature,
+                    bases=self._parse_bases(interface_match.group("bases")),
+                )
+            ]
+
+        type_match = re.match(rf"type\s+(?P<name>{_IDENTIFIER_RE})\b", subject)
+        if type_match:
+            name = type_match.group("name")
+            return [
+                SymbolDef(
+                    name=name,
+                    kind="type",
+                    qualified_name=name,
+                    line=line,
+                    signature=signature,
+                )
+            ]
+
+        enum_match = re.match(rf"enum\s+(?P<name>{_IDENTIFIER_RE})\b", subject)
+        if enum_match:
+            name = enum_match.group("name")
+            return [
+                SymbolDef(
+                    name=name,
+                    kind="enum",
+                    qualified_name=name,
+                    line=line,
+                    signature=signature,
+                )
+            ]
+
+        if not exported:
+            return None
+
+        variable_match = re.match(
+            rf"(?P<decl>const|let|var)\s+(?P<body>.+)",
+            subject,
+        )
+        if not variable_match:
+            return None
+
+        kind = "constant" if variable_match.group("decl") == "const" else "variable"
+        return [
+            SymbolDef(
+                name=name,
+                kind=kind,
+                qualified_name=name,
+                line=line,
+                signature=signature,
+            )
+            for name in self._extract_variable_names(variable_match.group("body"))
+        ]
+
+    def _build_signature_summary(
+        self,
+        *,
+        rel_path: str,
+        module_name: str,
+        package_name: str | None,
+        imports: list[str],
+        symbols: list[SymbolDef],
+        is_test_file: bool,
+    ) -> str:
+        """Build a compact TS/JS signature summary for hub splitting context."""
+        lines = [f"# Signatures from {rel_path}"]
+        lines.append(f"# module_name: {module_name}")
+        if package_name:
+            lines.append(f"# package: {package_name}")
+        if is_test_file:
+            lines.append("# test_file: true")
+
+        if imports:
+            lines.append("")
+            lines.append("## Imports")
+            for imported in imports:
+                lines.append(f'- "{imported}"')
+
+        buckets = {
+            "interface": [],
+            "type": [],
+            "enum": [],
+            "class": [],
+            "function": [],
+            "constant": [],
+            "variable": [],
+        }
+        entrypoints: list[str] = []
+        for symbol in symbols:
+            buckets.setdefault(symbol.kind, []).append(symbol.signature or symbol.name)
+            if symbol.is_entrypoint:
+                entrypoints.append(symbol.name)
+
+        if entrypoints:
+            lines.append("")
+            lines.append("## Entrypoints")
+            for entrypoint in entrypoints:
+                lines.append(f"- {entrypoint}")
+
+        for heading, key in (
+            ("Interfaces", "interface"),
+            ("Types", "type"),
+            ("Enums", "enum"),
+            ("Classes", "class"),
+            ("Functions", "function"),
+            ("Constants", "constant"),
+            ("Variables", "variable"),
+        ):
+            values = buckets.get(key, [])
+            if not values:
+                continue
+            lines.append("")
+            lines.append(f"## {heading}")
+            for value in values:
+                lines.append(f"- {value}")
+
+        return "\n".join(lines)
+
+    def _module_name(self, rel_path: str) -> str:
+        """Convert a source path into a stable extensionless module identity."""
+        normalized = rel_path.replace("\\", "/")
+        return self._strip_module_suffix(normalized)
+
+    def _package_name(self, rel_path: str) -> str | None:
+        """Return the parent directory as the package/grouping label."""
+        parent = posixpath.dirname(rel_path.replace("\\", "/"))
+        return parent or None
+
+    def _provided_modules(self, module_name: str) -> list[str]:
+        """Build import keys this file can satisfy for local TS/JS imports."""
+        provided = [module_name]
+        if module_name.startswith("src/"):
+            provided.append(module_name[4:])
+        if module_name.endswith("/index"):
+            parent = module_name[:-6]
+            if parent:
+                provided.append(parent)
+                if parent.startswith("src/"):
+                    provided.append(parent[4:])
+        return self._dedupe(provided)
+
+    def _normalize_import(self, raw: str, rel_path: str) -> str:
+        """Normalize relative imports to extensionless repo module identities."""
+        if not raw.startswith("."):
+            return raw
+        base_dir = posixpath.dirname(rel_path.replace("\\", "/"))
+        normalized = posixpath.normpath(posixpath.join(base_dir, raw))
+        if normalized == ".":
+            normalized = posixpath.basename(base_dir)
+        return self._strip_module_suffix(normalized)
+
+    def _is_test_file(self, rel_path: str) -> bool:
+        """Detect Jest/Vitest-style test files and __tests__ directories."""
+        normalized = rel_path.replace("\\", "/").lower()
+        parts = normalized.split("/")
+        return "__tests__" in parts or _TEST_FILE_RE.search(posixpath.basename(normalized)) is not None
+
+    def _test_targets(self, rel_path: str, import_refs: list[_ImportRef]) -> list[str]:
+        """Infer test target modules from colocated names and relative imports."""
+        targets: list[str] = []
+        guessed = self._guess_test_target(rel_path)
+        if guessed:
+            targets.append(guessed)
+        targets.extend(ref.normalized for ref in import_refs if ref.is_relative)
+        return self._dedupe(targets)
+
+    def _guess_test_target(self, rel_path: str) -> str | None:
+        """Guess the implementation module covered by a TS/JS test file."""
+        normalized = rel_path.replace("\\", "/")
+        dirname = posixpath.dirname(normalized)
+        basename = posixpath.basename(normalized)
+        match = re.match(
+            r"(?P<name>.+)\.(?:test|spec)\.(?:ts|tsx|js|jsx)$",
+            basename,
+            re.IGNORECASE,
+        )
+        if "__tests__" in normalized.split("/"):
+            parts = normalized.split("/")
+            test_index = parts.index("__tests__")
+            target_dir = "/".join(parts[:test_index])
+            raw_name = match.group("name") if match else self._strip_module_suffix(basename)
+            return posixpath.normpath(posixpath.join(target_dir, raw_name))
+        if match:
+            return posixpath.normpath(posixpath.join(dirname, match.group("name")))
+        return None
+
+    def _collect_declaration(self, lines: list[str], start_index: int) -> str:
+        """Collect a compact declaration header from the current line."""
+        collected: list[str] = []
+        paren_depth = 0
+        for index in range(start_index, min(start_index + 12, len(lines))):
+            line = lines[index].rstrip()
+            collected.append(line)
+            masked = self._mask_non_code(line)
+            paren_depth += masked.count("(") - masked.count(")")
+            stripped = line.strip()
+            if index == start_index and stripped.endswith(";"):
+                break
+            if paren_depth <= 0 and ("{" in masked or ";" in masked):
+                break
+        return "\n".join(collected)
+
+    def _strip_modifiers(self, normalized: str) -> tuple[str, bool]:
+        """Remove leading TS declaration modifiers while preserving export state."""
+        subject = normalized
+        exported = False
+        while True:
+            if subject.startswith("export "):
+                exported = True
+                subject = subject[7:].lstrip()
+                continue
+            for modifier in ("default ", "declare ", "abstract "):
+                if subject.startswith(modifier):
+                    subject = subject[len(modifier):].lstrip()
+                    break
+            else:
+                return subject, exported
+
+    def _extract_variable_names(self, body: str) -> list[str]:
+        """Extract simple identifier names from an exported variable declaration."""
+        names: list[str] = []
+        for piece in self._split_top_level_commas(body):
+            match = re.match(rf"\s*(?P<name>{_IDENTIFIER_RE})\b", piece)
+            if match:
+                names.append(match.group("name"))
+        return self._dedupe(names)
+
+    def _split_top_level_commas(self, body: str) -> list[str]:
+        """Split a variable declaration body on commas outside brackets."""
+        pieces: list[str] = []
+        start = 0
+        depth = 0
+        for index, char in enumerate(body):
+            if char in "([{<":
+                depth += 1
+            elif char in ")]}>":
+                depth = max(0, depth - 1)
+            elif char == "," and depth == 0:
+                pieces.append(body[start:index])
+                start = index + 1
+        pieces.append(body[start:])
+        return pieces
+
+    def _parse_bases(self, raw_bases: str | None) -> list[str]:
+        """Parse class/interface base clauses into compact names."""
+        if not raw_bases:
+            return []
+        cleaned = raw_bases.strip().rstrip("{").strip()
+        return [
+            item.strip()
+            for item in self._split_top_level_commas(cleaned)
+            if item.strip()
+        ]
+
+    def _has_main_guard(self, content: str) -> bool:
+        """Detect common JS/TS script entrypoint guards."""
+        return (
+            "require.main === module" in content
+            or "require.main == module" in content
+            or "import.meta.main" in content
+        )
+
+    def _strip_module_suffix(self, value: str) -> str:
+        """Remove JS/TS module file suffixes from a path-like value."""
+        for suffix in _MODULE_SUFFIXES:
+            if value.endswith(suffix):
+                return value[: -len(suffix)]
+        return value
+
+    def _strip_comments(self, content: str) -> str:
+        """Remove line and block comments while preserving string literals."""
+        result: list[str] = []
+        index = 0
+        length = len(content)
+        quote: str | None = None
+        while index < length:
+            char = content[index]
+            next_char = content[index + 1] if index + 1 < length else ""
+            if quote:
+                result.append(char)
+                if char == "\\" and index + 1 < length:
+                    result.append(content[index + 1])
+                    index += 2
+                    continue
+                if char == quote:
+                    quote = None
+                index += 1
+                continue
+
+            if char in {"'", '"', "`"}:
+                quote = char
+                result.append(char)
+                index += 1
+                continue
+            if char == "/" and next_char == "/":
+                while index < length and content[index] != "\n":
+                    result.append(" ")
+                    index += 1
+                continue
+            if char == "/" and next_char == "*":
+                result.extend((" ", " "))
+                index += 2
+                while index < length - 1:
+                    if content[index] == "*" and content[index + 1] == "/":
+                        result.extend((" ", " "))
+                        index += 2
+                        break
+                    result.append("\n" if content[index] == "\n" else " ")
+                    index += 1
+                continue
+            result.append(char)
+            index += 1
+        return "".join(result)
+
+    def _mask_non_code(self, content: str) -> str:
+        """Mask strings and comments for brace/paren depth accounting."""
+        stripped = self._strip_comments(content)
+        result: list[str] = []
+        index = 0
+        length = len(stripped)
+        quote: str | None = None
+        while index < length:
+            char = stripped[index]
+            if quote:
+                result.append("\n" if char == "\n" else " ")
+                if char == "\\" and index + 1 < length:
+                    result.append("\n" if stripped[index + 1] == "\n" else " ")
+                    index += 2
+                    continue
+                if char == quote:
+                    quote = None
+                index += 1
+                continue
+            if char in {"'", '"', "`"}:
+                quote = char
+                result.append(" ")
+                index += 1
+                continue
+            result.append(char)
+            index += 1
+        return "".join(result)
+
+    def _normalize_spaces(self, text: str) -> str:
+        """Normalize declaration whitespace for regex matching."""
+        return " ".join(text.split())
+
+    def _dedupe(self, values: list[str]) -> list[str]:
+        """Deduplicate strings while preserving order."""
+        seen: set[str] = set()
+        result: list[str] = []
+        for value in values:
+            if not value or value in seen:
+                continue
+            seen.add(value)
+            result.append(value)
+        return result
+
+    def _dedupe_import_refs(self, refs: list[_ImportRef]) -> list[_ImportRef]:
+        """Deduplicate import refs by normalized module while preserving order."""
+        seen: set[str] = set()
+        result: list[_ImportRef] = []
+        for ref in refs:
+            if not ref.normalized or ref.normalized in seen:
+                continue
+            seen.add(ref.normalized)
+            result.append(ref)
+        return result

--- a/engine/antigravity_engine/hub/module_grouping.py
+++ b/engine/antigravity_engine/hub/module_grouping.py
@@ -162,7 +162,7 @@ def load_module_files(module_path: Path, workspace: Path) -> list[SourceFile]:
         except OSError:
             continue
 
-        rel = str(fpath.relative_to(workspace))
+        rel = fpath.relative_to(workspace).as_posix()
         raw_tokens = len(content) // 4
 
         # Skip oversized files (likely bundled/generated, not source)

--- a/engine/tests/test_hub_module_grouping.py
+++ b/engine/tests/test_hub_module_grouping.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 
 from antigravity_engine.hub._constants import WORKSPACE_ROOT_MODULE_ID
-from antigravity_engine.hub.module_grouping import load_module_files
+from antigravity_engine.hub.module_grouping import group_files, load_module_files
 from antigravity_engine.hub.scanner import detect_modules, resolve_module_path
 
 
@@ -53,3 +53,72 @@ def test_load_module_files_limits_workspace_root_to_direct_files(tmp_path: Path)
     loaded = load_module_files(resolve_module_path(tmp_path, WORKSPACE_ROOT_MODULE_ID), tmp_path)
 
     assert [item.rel_path for item in loaded] == ["main.go"]
+
+
+def test_typescript_grouping_uses_local_import_edges(tmp_path: Path) -> None:
+    """Related TS/JS files should group together through semantic import keys."""
+    _write_text(
+        tmp_path / "src" / "feature" / "service.ts",
+        (
+            'import { getUser } from "./repo";\n'
+            'import { User } from "./types";\n\n'
+            "export function loadUser(id: string): User {\n"
+            "    return getUser(id);\n"
+            "}\n\n"
+            + ("// semantic padding\n" * 220)
+        ),
+    )
+    _write_text(
+        tmp_path / "src" / "feature" / "repo.ts",
+        (
+            'import type { User } from "./types";\n\n'
+            "export class UserRepo {}\n\n"
+            "export function getUser(id: string): User {\n"
+            "    return { id };\n"
+            "}\n\n"
+            + ("// semantic padding\n" * 220)
+        ),
+    )
+    _write_text(
+        tmp_path / "src" / "feature" / "types.ts",
+        (
+            "export interface User {\n"
+            "    id: string;\n"
+            "}\n\n"
+            + ("// semantic padding\n" * 220)
+        ),
+    )
+    _write_text(
+        tmp_path / "src" / "other" / "logger.ts",
+        "export function log(value: string): void { console.log(value); }\n",
+    )
+    _write_text(
+        tmp_path / "src" / "feature" / "__tests__" / "service.test.ts",
+        (
+            'import { loadUser } from "../service";\n\n'
+            "test('loads user', () => loadUser('1'));\n"
+        ),
+    )
+
+    files = load_module_files(tmp_path / "src", tmp_path)
+    groups = group_files(files, tmp_path, token_budget=3400)
+    group_paths = [sorted(source_file.rel_path for source_file in group.files) for group in groups]
+
+    assert any(
+        {
+            "src/feature/service.ts",
+            "src/feature/repo.ts",
+            "src/feature/types.ts",
+        }.issubset(set(paths))
+        for paths in group_paths
+    )
+    assert any(
+        paths == ["src/feature/__tests__/service.test.ts"]
+        for paths in group_paths
+    )
+
+
+def _write_text(path: Path, content: str) -> None:
+    """Write a text fixture file, creating parent directories as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")

--- a/engine/tests/test_hub_semantic_graph.py
+++ b/engine/tests/test_hub_semantic_graph.py
@@ -83,6 +83,113 @@ def test_go_adapter_extracts_package_imports_symbols_entrypoints_and_tests(
     assert test_semantics.test_targets == ["example.com/app/internal/service"]
 
 
+def test_typescript_adapter_extracts_imports_symbols_and_tests(tmp_path: Path) -> None:
+    """TS/JS adapter should capture imports, exported symbols, and test metadata."""
+    _write_text(
+        tmp_path / "src" / "components" / "widget.tsx",
+        (
+            'import React from "react";\n'
+            'import type { User } from "./types";\n'
+            'import "./setup";\n'
+            'const lazy = () => import("../plugins/lazy");\n'
+            'const toolkit = require("@scope/toolkit");\n'
+            'export { helper } from "./helper";\n\n'
+            "export interface WidgetProps extends Record<string, unknown> {\n"
+            "    user: User;\n"
+            "}\n\n"
+            "export type WidgetMode = 'compact' | 'full';\n\n"
+            "export enum WidgetKind {\n"
+            "    Card = 'card',\n"
+            "}\n\n"
+            "export async function loadWidget(id: string): Promise<User> {\n"
+            "    return toolkit.load(id);\n"
+            "}\n\n"
+            "export class WidgetCard extends React.Component<WidgetProps> {}\n\n"
+            "export const WidgetBadge = ({ user }: WidgetProps) => <span>{user.id}</span>;\n"
+            "export let widgetVersion = '1';\n"
+            "export var legacyWidget = true;\n"
+        ),
+    )
+    _write_text(
+        tmp_path / "src" / "components" / "widget.test.tsx",
+        (
+            'import { WidgetBadge } from "./widget";\n\n'
+            "describe('WidgetBadge', () => {\n"
+            "    it('renders', () => WidgetBadge);\n"
+            "});\n"
+        ),
+    )
+
+    semantics = analyze_source_file(
+        tmp_path,
+        tmp_path / "src" / "components" / "widget.tsx",
+    )
+    test_semantics = analyze_source_file(
+        tmp_path,
+        tmp_path / "src" / "components" / "widget.test.tsx",
+    )
+
+    assert semantics.language == "TypeScript (React)"
+    assert semantics.adapter_name == "typescript"
+    assert set(semantics.imports) == {
+        "react",
+        "src/components/types",
+        "src/components/setup",
+        "src/plugins/lazy",
+        "@scope/toolkit",
+        "src/components/helper",
+    }
+    assert semantics.package_identity == "src/components/widget"
+    assert "src/components/widget" in semantics.provided_modules
+    assert "components/widget" in semantics.provided_modules
+
+    symbols = {symbol.name: symbol.kind for symbol in semantics.symbols}
+    assert symbols == {
+        "WidgetProps": "interface",
+        "WidgetMode": "type",
+        "WidgetKind": "enum",
+        "loadWidget": "function",
+        "WidgetCard": "class",
+        "WidgetBadge": "constant",
+        "widgetVersion": "variable",
+        "legacyWidget": "variable",
+    }
+    assert "## Imports" in semantics.signature_summary
+    assert "## Functions" in semantics.signature_summary
+    assert "export async function loadWidget" in semantics.signature_summary
+
+    assert test_semantics.is_test_file is True
+    assert test_semantics.test_targets == ["src/components/widget"]
+
+
+def test_javascript_adapter_extracts_commonjs_and_export_symbols(tmp_path: Path) -> None:
+    """JS files should use the TS/JS adapter instead of generic fallback."""
+    _write_text(
+        tmp_path / "src" / "index.js",
+        (
+            'const fs = require("node:fs");\n'
+            'const worker = require("./worker");\n'
+            'export { createThing } from "./thing";\n'
+            "export function main() {\n"
+            "    return worker.run(fs);\n"
+            "}\n"
+            "export class App {}\n"
+            "export const VERSION = '1';\n"
+        ),
+    )
+
+    semantics = analyze_source_file(tmp_path, tmp_path / "src" / "index.js")
+
+    assert semantics.language == "JavaScript"
+    assert semantics.adapter_name == "typescript"
+    assert semantics.imports == ["node:fs", "src/worker", "src/thing"]
+    assert {symbol.name: symbol.kind for symbol in semantics.symbols} == {
+        "main": "function",
+        "App": "class",
+        "VERSION": "constant",
+    }
+
+
 def test_go_knowledge_graph_contains_semantic_edges(tmp_path: Path) -> None:
     """A Go workspace should contribute non-zero semantic graph edges."""
     _write_go_workspace(tmp_path)
@@ -112,6 +219,41 @@ def test_go_knowledge_graph_contains_semantic_edges(tmp_path: Path) -> None:
         and node.get("type") == "method"
         for node in nodes
     )
+
+
+def test_typescript_knowledge_graph_contains_adapter_summary_and_import_edges(
+    tmp_path: Path,
+) -> None:
+    """A TS workspace should contribute adapter diagnostics and import edges."""
+    _write_text(
+        tmp_path / "src" / "types.ts",
+        "export interface User { id: string }\n",
+    )
+    _write_text(
+        tmp_path / "src" / "service.ts",
+        (
+            'import { User } from "./types";\n\n'
+            "export function loadUser(id: string): User {\n"
+            "    return { id };\n"
+            "}\n"
+        ),
+    )
+
+    graph = build_knowledge_graph(tmp_path, full_scan(tmp_path))
+    edges = graph["edges"]
+
+    assert graph["summary"]["semantic_adapters"] == {"typescript": 2}
+    assert graph["summary"]["generic_fallback_file_count"] == 0
+    assert {
+        "from": "file:src/service.ts",
+        "to": "module:src/types",
+        "type": "imports",
+    } in edges
+    assert {
+        "from": "file:src/service.ts",
+        "to": "symbol:src/service.ts:loadUser",
+        "type": "defines",
+    } in edges
 
 
 def test_go_module_grouping_uses_semantic_package_and_import_signals(

--- a/engine/tests/test_hub_semantic_graph.py
+++ b/engine/tests/test_hub_semantic_graph.py
@@ -190,6 +190,28 @@ def test_javascript_adapter_extracts_commonjs_and_export_symbols(tmp_path: Path)
     }
 
 
+def test_typescript_adapter_ignores_import_like_text_inside_strings(
+    tmp_path: Path,
+) -> None:
+    """Import-like text inside strings should not create dependency edges."""
+    _write_text(
+        tmp_path / "src" / "strings.ts",
+        (
+            'const fakeRequire = "require(\\"not-a-real-module\\")";\n'
+            "const fakeDynamic = 'import(\"also-fake\")';\n"
+            "const fakeStatic = `import { nope } from \"template-fake\"`;\n"
+            "const fakeExport = 'export { nope } from \"export-fake\"';\n"
+            'import { real } from "./real";\n'
+            'const lazy = import("./lazy");\n'
+            'const toolkit = require("@scope/real");\n'
+        ),
+    )
+
+    semantics = analyze_source_file(tmp_path, tmp_path / "src" / "strings.ts")
+
+    assert semantics.imports == ["src/real", "src/lazy", "@scope/real"]
+
+
 def test_go_knowledge_graph_contains_semantic_edges(tmp_path: Path) -> None:
     """A Go workspace should contribute non-zero semantic graph edges."""
     _write_go_workspace(tmp_path)


### PR DESCRIPTION
## 变更内容
- 新增 TypeScript / JavaScript 专用语义 adapter，支持 `.ts/.tsx/.js/.jsx`
- 提取 import / export / require / dynamic import 关系
- 提取顶层 function / class / interface / type / enum / exported 变量符号
- 接入 knowledge graph 与 module grouping
- 更新文档并补充 focused tests

## 验证
- `python -m pytest engine/tests/test_hub_semantic_graph.py engine/tests/test_hub_module_grouping.py -q`
- 结果：`18 passed`