### PR TITLE
fix(security): prevent search_code symlink path escape

### DIFF
--- a/engine/antigravity_engine/hub/ask_tools.py
+++ b/engine/antigravity_engine/hub/ask_tools.py
@@ -181,12 +181,15 @@ def create_ask_tools(workspace: Path) -> dict[str, Callable]:
                 if file_pattern != "*" and not fnmatch.fnmatch(fname, file_pattern):
                     continue
                 fpath = Path(dirpath_str) / fname
+                resolved = fpath.resolve()
+                if not is_safe_path(ws, resolved):
+                    continue
                 try:
                     rel = fpath.relative_to(ws)
                 except ValueError:
                     continue
                 try:
-                    text = fpath.read_text(encoding="utf-8", errors="replace")
+                    text = resolved.read_text(encoding="utf-8", errors="replace")
                 except OSError:
                     continue
                 for lineno, line in enumerate(text.splitlines(), 1):

--- a/engine/tests/test_ask_tools.py
+++ b/engine/tests/test_ask_tools.py
@@ -56,6 +56,17 @@ def test_search_code_empty_query(tmp_path: Path) -> None:
     assert "Error" in result
 
 
+def test_search_code_skips_symlink_outside_workspace(tmp_path: Path) -> None:
+    outside_file = tmp_path.parent / "outside-secret.txt"
+    outside_file.write_text("AG_LEAK_TOKEN=outside-symlink-secret-12345\n")
+    (tmp_path / "linked_secret.env").symlink_to(outside_file)
+
+    tools = _make_tools(tmp_path)
+    result = tools["search_code"]("AG_LEAK_TOKEN")
+    assert "No results" in result
+    assert "linked_secret.env" not in result
+
+
 # ---------------------------------------------------------------------------
 # read_file
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- `search_code` walked workspace paths and read files without resolving targets or enforcing `is_safe_path`, allowing in-repo symlinks to disclose files outside the project. 
- The structured-agent tooling exposes these tool outputs to LLMs and persists raw outputs, increasing the severity of any disclosure.

### Description
- Resolve each candidate path in `search_code` and skip any target where `is_safe_path(ws, resolved)` is false so symlink targets outside the workspace are not read. 
- Read file contents from the resolved, validated path (`resolved.read_text(...)`) instead of the original `fpath`. 
- Add a regression test `test_search_code_skips_symlink_outside_workspace` that creates an in-repo symlink to an outside file and asserts `search_code` does not return matches from that symlink. 
- Modified files: `engine/antigravity_engine/hub/ask_tools.py` and `engine/tests/test_ask_tools.py`.

### Testing
- Ran `pytest -q engine/tests/test_ask_tools.py -k "search_code"`, which completed successfully with `7 passed, 11 deselected`.
- The new regression test verifies symlink escapes are blocked and the existing search behavior is preserved for normal files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d83b2da688330831cb6b4ccdc9bd1)