### PR TITLE
fix(hub): prevent project-context symlink exfiltration

### DIFF
--- a/engine/antigravity_engine/hub/ask_pipeline.py
+++ b/engine/antigravity_engine/hub/ask_pipeline.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 
 from antigravity_engine.hub._constants import SKIP_DIRS
+from antigravity_engine.hub._utils import is_safe_path
 from antigravity_engine.hub.contracts import (
     ClaimVerification,
     ModuleClaim,
@@ -486,6 +487,7 @@ def _load_project_context(
     per_source_cap = max(1000, max_chars // 3)
     budget = max_chars
     parts: list[str] = []
+    workspace = ag_dir.parent
 
     def _push(label: str, content: str) -> None:
         nonlocal budget
@@ -495,6 +497,25 @@ def _load_project_context(
         parts.append(f"### {label}\n{chunk}")
         budget -= len(chunk)
 
+    def _read_project_doc(path: Path) -> str:
+        """Read a bounded project doc only when it resolves inside workspace."""
+        if budget <= 0:
+            return ""
+        limit = min(per_source_cap, budget)
+        try:
+            resolved = path.resolve()
+        except OSError:
+            return ""
+        if not is_safe_path(workspace, resolved):
+            return ""
+        try:
+            if not resolved.is_file():
+                return ""
+            with resolved.open("r", encoding="utf-8", errors="replace") as f:
+                return f.read(limit)
+        except OSError:
+            return ""
+
     file_sources: list[tuple[str, Path]] = [
         ("Project Conventions (.antigravity/conventions.md)", ag_dir / "conventions.md"),
         ("Document Index (.antigravity/document_index.md)", ag_dir / "document_index.md"),
@@ -502,12 +523,9 @@ def _load_project_context(
     for label, path in file_sources:
         if budget <= 0:
             break
-        if not path.is_file():
-            continue
-        try:
-            _push(label, path.read_text(encoding="utf-8"))
-        except OSError:
-            continue
+        content = _read_project_doc(path)
+        if content:
+            _push(label, content)
 
     if budget > 0 and map_content.strip():
         _push("Module Map (.antigravity/map.md)", map_content)
@@ -519,12 +537,9 @@ def _load_project_context(
     for label, path in file_sources_after_map:
         if budget <= 0:
             break
-        if not path.is_file():
-            continue
-        try:
-            _push(label, path.read_text(encoding="utf-8"))
-        except OSError:
-            continue
+        content = _read_project_doc(path)
+        if content:
+            _push(label, content)
 
     if not parts:
         return ""

--- a/engine/tests/test_hub_pipeline.py
+++ b/engine/tests/test_hub_pipeline.py
@@ -261,6 +261,20 @@ def test_load_project_context_respects_total_budget(tmp_path: Path) -> None:
     assert "REGISTRY_MARKER" in section
 
 
+def test_load_project_context_skips_symlink_outside_workspace(tmp_path: Path) -> None:
+    """Symlinked project docs resolving outside workspace must be ignored."""
+    from antigravity_engine.hub.ask_pipeline import _load_project_context
+
+    ag_dir = tmp_path / ".antigravity"
+    ag_dir.mkdir()
+    outside = tmp_path.parent / "outside-secret.txt"
+    outside.write_text("SECRET_TOKEN_OUTSIDE\n", encoding="utf-8")
+    (ag_dir / "conventions.md").symlink_to(outside)
+
+    section = _load_project_context(ag_dir, map_content="")
+    assert section == ""
+
+
 # ---------------------------------------------------------------------------
 # Phase 1: config/entry/git in _format_scan_report
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- `_load_project_context` previously used `Path.is_file()` and `Path.read_text()` which follow symlinks and can read files outside the workspace, allowing a malicious repo to cause exfiltration of host secrets into LLM prompts. 
- The helper also read entire files before applying the character cap, increasing exposure for large symlink targets.

### Description

- Hardened `_load_project_context` in `engine/antigravity_engine/hub/ask_pipeline.py` to resolve candidate paths and validate them with `is_safe_path(workspace, resolved)` before reading. 
- Replaced full-file `read_text()` usage with a bounded reader `resolved.open().read(limit)` that only reads up to the current per-source/budget slice. 
- Added a small helper `def _read_project_doc(path: Path) -> str` to centralize resolve/validate/bounded-read logic and silently skip unsafe or unreadable sources. 
- Added regression test `test_load_project_context_skips_symlink_outside_workspace` in `engine/tests/test_hub_pipeline.py` to ensure symlinked project docs resolving outside the workspace are ignored.

### Testing

- Ran `pytest -q engine/tests/test_hub_pipeline.py -k project_context` and the project-context-related tests passed (4 passed, 13 deselected) with only pytest mark warnings unrelated to the change. 
- The new test `test_load_project_context_skips_symlink_outside_workspace` was executed and succeeded, verifying the symlink-exclusion behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d837eda888330bb5d60c6db4e4c3e)