### PR TITLE
refactor(engine): remove GitNexus integration + harden ask honesty

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@
 <br/>
 
 <div align="center">
-<img src="docs/assets/demo.gif" alt="ag-ask demo" width="820" onerror="this.style.display='none'"/>
 <img src="docs/assets/before_after.png" alt="Before vs After Antigravity" width="800"/>
 </div>
 
@@ -232,7 +231,7 @@ Time: a few minutes for small repos, longer for large ones. Requires `ag-setup` 
 
 ### `ag-ask` — routed Q&A on the codebase
 
-The **main reason this plugin exists**. Routes your question to the right ModuleAgent (and GitAgent / GitNexus when applicable), then returns an answer grounded in actual source with file paths and line numbers. Use it **before** manually grepping or reading files — it's faster and more accurate. Good question shapes: "where is X defined/handled?", "why was Y done this way?", "how does the auth flow work?", "what depends on module Z?".
+The **main reason this plugin exists**. Routes your question to the right ModuleAgent (and GitAgent when applicable), then returns an answer grounded in actual source with file paths and line numbers. Use it **before** manually grepping or reading files — it's faster and more accurate. Good question shapes: "where is X defined/handled?", "why was Y done this way?", "how does the auth flow work?", "what depends on module Z?".
 
 Requires a knowledge base — if you see "no index" or empty answers, run `ag-refresh` first.
 
@@ -272,18 +271,16 @@ The native plugins are the first-class install path today. Other environments ar
        └──► ag-mcp         Optional MCP server → IDE tool integration
 ```
 
-**Dynamic Multi-Agent Cluster** — During `ag-refresh`, files are grouped by import graph, directory co-location, and filename prefix. Each sub-agent gets ~30K tokens of focused, related code pre-loaded (no tool calls needed) and writes a **comprehensive Markdown knowledge doc** to `agents/*.md`. Large modules → multiple agent docs in parallel (no merging, no information loss). A **Map Agent** indexes everything into `map.md`. During `ag-ask`, the Router reads `map.md` to pick modules, then feeds their agent docs to answer agents. For structural questions (call chains, dependencies, impact), it automatically queries [GitNexus](https://github.com/abhigyanpatwari/GitNexus). **Fully language-agnostic** — pure directory-structure module detection, LLM-driven code analysis.
+**Dynamic Multi-Agent Cluster** — During `ag-refresh`, files are grouped by import graph, directory co-location, and filename prefix. Each sub-agent gets ~30K tokens of focused, related code pre-loaded (no tool calls needed) and writes a **comprehensive Markdown knowledge doc** to `agents/*.md`. Large modules → multiple agent docs in parallel (no merging, no information loss). A **Map Agent** indexes everything into `map.md`. During `ag-ask`, the Router reads `map.md` to pick modules, then feeds their agent docs to answer agents. **Fully language-agnostic** — pure directory-structure module detection, LLM-driven code analysis.
 
 **GitAgent** — Dedicated agent for analyzing git history — who changed what and why.
-
-**GitNexus Graph Enrichment (optional)** — Install [GitNexus](https://github.com/abhigyanpatwari/GitNexus) to auto-unlock graph-enriched answers. The Router LLM decides when a question needs structural analysis and queries GitNexus automatically.
 
 **NLPM Audit Feedback** — Improved by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural-language programming linter by [xiaolai](https://github.com/xiaolai).
 
 <details>
 <summary><b>Detailed pipeline & internals</b></summary>
 
-### `ag-refresh` — Multi-agent self-learning (9-step pipeline)
+### `ag-refresh` — Multi-agent self-learning (8-step pipeline)
 
 ```bash
 ag-refresh --workspace my-project
@@ -297,16 +294,14 @@ ag-refresh --workspace my-project
 6. **LLM full-context analysis** — group files by import graph + directory + prefix, pre-load into context (~30K tokens per sub-agent), filter out build artifacts. Each sub-agent reads the full source code and outputs a **comprehensive Markdown knowledge document** (`agents/*.md`). Large modules get multiple agent docs (one per group, no merging). Global API concurrency control prevents rate-limiting. **Fully language-agnostic** — works with any programming language.
 7. **RefreshGitAgent** analyzes git history, generates `_git_insights.md`
 8. **Map Agent** reads all agent docs → generates `map.md` (module routing index with descriptions and key topics)
-9. **GitNexus indexing** (optional) — runs `gitnexus analyze` to build a Tree-sitter code graph (16 languages, call chains, dependencies). Auto-skipped if GitNexus is not installed.
 
-### `ag-ask` — Router-based Q&A (dual-path)
+### `ag-ask` — Router-based Q&A
 
 ```bash
 ag-ask "How does auth work in this project?"
 ```
 
-- **Semantic path**: Router reads `map.md` → selects modules → reads `agents/*.md` → LLM answers with code references. Multiple agent docs are read in parallel, then a Synthesizer combines answers.
-- **Graph path** (automatic): Router LLM decides if the question needs structural analysis → queries GitNexus for call chains, dependencies, or impact → injects graph data into the answer context. Silently skipped if GitNexus is not installed.
+Router reads `map.md` → selects modules → reads `agents/*.md` → LLM answers with code references. Multiple agent docs are read in parallel, then a Synthesizer combines answers.
 
 Falls back to the legacy Router → ModuleAgent/GitAgent swarm when agent docs are not yet generated.
 
@@ -315,7 +310,6 @@ Falls back to the legacy Router → ModuleAgent/GitAgent swarm when agent docs a
 - **LLM as analyzer**: No AST parsing or regex — source code is fed directly to LLMs. Works with any programming language out of the box.
 - **Smart grouping**: Files grouped by import relationships, directory co-location, filename prefixes. Build artifacts filtered. Hard character limit (800K) prevents context overflow.
 - **No information loss**: Large modules produce multiple `agent.md` files — no merging or compression. Parallel reads + Synthesizer recombines at answer time.
-- **Graph-enriched answers**: Router decides when structural data (call chains, dependencies, impact) is needed and queries GitNexus.
 - **Global API concurrency control**: `AG_API_CONCURRENCY` limits total simultaneous LLM calls.
 - **Language-agnostic module detection**: Pure directory structure — no `__init__.py` or any language-specific marker required.
 
@@ -391,47 +385,6 @@ claude mcp add antigravity ag-mcp -- --workspace /path/to/project
 ```
 
 Set `MCP_ENABLED=true` in `.env` to make configured servers available, and set `AG_ALLOW_MCP=true` only when you want `ag-ask` to auto-connect those external servers. Stdio MCP servers inherit process environment plus configured `env` values, so treat enabled servers as local-permission code.
-
-</details>
-
-<details>
-<summary><b>GitNexus Graph Enrichment — Automatic structural intelligence</b></summary>
-
-[GitNexus](https://github.com/abhigyanpatwari/GitNexus) builds a code knowledge graph using **Tree-sitter AST parsing** (16 languages). When installed, Antigravity integrates it at two levels:
-
-**1. Refresh-time indexing** — `ag-refresh` automatically runs `gitnexus analyze` (Step 9) to build/update the code graph. Skipped silently if GitNexus is not installed.
-
-**2. Ask-time graph enrichment** — The Router LLM decides whether a question needs structural analysis:
-- "What does the auth module do?" → `GRAPH: no` → pure agent.md answer
-- "Who calls handleLogin?" → `GRAPH: yes` → queries GitNexus → graph data + agent.md → enriched answer
-
-```
-User: "What functions call the send method in gateway?"
-
-Router: MODULES: gateway, tests_gateway | GRAPH: yes
-  → GitNexus query returns call chains with confidence scores
-  → Agent docs provide semantic context (what each caller does)
-  → Combined answer: precise call chain + file paths + line numbers + purpose
-```
-
-| Capability | What it provides |
-|:-----------|:-----------------|
-| `gitnexus_query` | Hybrid search (BM25 + semantic) — execution flows, not just files |
-| `gitnexus_context` | 360-degree symbol view: callers, callees, references, definition |
-| `gitnexus_impact` | Blast radius analysis — what breaks if you change a symbol? |
-
-> **Note:** GitNexus is NOT bundled with Antigravity. It requires separate installation via npm (`npm install -g gitnexus`). Antigravity works fully without it — when not installed, all graph features are silently skipped with zero overhead.
-
-```bash
-# 1. Install GitNexus (requires Node.js)
-npm install -g gitnexus
-
-# 2. Refresh (auto-indexes the code graph)
-ag-refresh --workspace my-project
-
-# 3. Ask — graph enrichment is automatic
-ag-ask "Who calls the send method in gateway adapters?"
-```
 
 </details>
 
@@ -585,7 +538,7 @@ Ideas are contributions too! Open an [issue](https://github.com/study8677/antigr
         <img src="https://github.com/abhigyanpatwari.png" width="80" /><br/>
         <b>Abhigyan Patwari</b>
       </a><br/>
-      <sub><a href="https://github.com/abhigyanpatwari/GitNexus">GitNexus</a> — code knowledge graph natively integrated into <code>ag ask</code> for symbol search, call graphs, and impact analysis</sub>
+      <sub>Code knowledge graph integration for <code>ag ask</code> — symbol search, call graphs, and impact analysis</sub>
     </td>
     <td align="center" width="20%">
       <a href="https://github.com/BBear0115">

--- a/README_CN.md
+++ b/README_CN.md
@@ -109,7 +109,7 @@
 
 ### `ag-ask` —— 路由问答
 
-**插件存在的主要原因**。把问题路由到合适的 ModuleAgent（必要时也调 GitAgent / GitNexus），返回有据可查的答案，附带文件路径和行号。**优先使用它**而非手动 grep / 读文件 —— 更快也更准。适合的问题形态：「X 在哪里定义/处理？」、「Y 为什么这样设计？」、「认证流程是怎样的？」、「哪些地方依赖模块 Z？」。
+**插件存在的主要原因**。把问题路由到合适的 ModuleAgent（必要时也调 GitAgent），返回有据可查的答案，附带文件路径和行号。**优先使用它**而非手动 grep / 读文件 —— 更快也更准。适合的问题形态：「X 在哪里定义/处理？」、「Y 为什么这样设计？」、「认证流程是怎样的？」、「哪些地方依赖模块 Z？」。
 
 ```
 # Claude Code
@@ -209,11 +209,9 @@ ag init my-project && cd my-project
        └──► ag-mcp         可选 MCP 服务端 → IDE 工具集成
 ```
 
-**动态多智能体集群** —— `ag-refresh` 时，引擎使用**智能功能分组**：基于 import 关系、目录共位、文件名前缀将文件聚类。源码直接预加载进 agent 上下文（无需工具调用），构建产物自动过滤。每个 sub-agent 分析约 30K tokens 的聚焦代码，只需 1 次 LLM 调用，输出**全面的 Markdown 知识文档**（`agents/*.md`）。大模块由多个 sub-agent 并行分析——每个输出独立 agent.md（不合并、不压缩）。**Map Agent** 读取所有 agent 文档生成 `map.md` 路由索引。`ag-ask` 时，Router 读取 `map.md` 选择相关模块，将 agent 文档喂给 answer agent。对于结构性问题（调用链、依赖关系、影响分析），Router 自动查询 [GitNexus](https://github.com/abhigyanpatwari/GitNexus) 代码图谱获取精确关系。**完全语言无关** —— 模块检测使用纯目录结构，代码分析完全由 LLM 完成。支持任何编程语言。
+**动态多智能体集群** —— `ag-refresh` 时，引擎使用**智能功能分组**：基于 import 关系、目录共位、文件名前缀将文件聚类。源码直接预加载进 agent 上下文（无需工具调用），构建产物自动过滤。每个 sub-agent 分析约 30K tokens 的聚焦代码，只需 1 次 LLM 调用，输出**全面的 Markdown 知识文档**（`agents/*.md`）。大模块由多个 sub-agent 并行分析——每个输出独立 agent.md（不合并、不压缩）。**Map Agent** 读取所有 agent 文档生成 `map.md` 路由索引。`ag-ask` 时，Router 读取 `map.md` 选择相关模块，将 agent 文档喂给 answer agent。**完全语言无关** —— 模块检测使用纯目录结构，代码分析完全由 LLM 完成。支持任何编程语言。
 
 **GitAgent** —— 专门分析 git 历史的 Agent，了解「谁改了什么、为什么改」。
-
-**GitNexus 图谱增强（可选）** —— 安装 [GitNexus](https://github.com/abhigyanpatwari/GitNexus) 后自动解锁图谱增强回答。Router LLM 判断问题是否需要结构分析（调用链、依赖、影响范围），自动查询 GitNexus —— 将精确的图谱数据与 agent 文档的语义理解结合。
 
 **NLPM 审计反馈** —— 本仓库受益于 [xiaolai](https://github.com/xiaolai) 的 [NLPM](https://github.com/xiaolai/nlpm-for-claude)，它是面向 Claude Code 插件、skills 和 agent 定义的自然语言编程 linter。它的审计帮助发现了 skill frontmatter 和依赖版本卫生方面的真实改进点。
 
@@ -250,9 +248,9 @@ antigravity-workspace-template/
         ├── hub/             # ★ 核心：多智能体集群
         │   ├── agents.py    #   Router + ModuleAgent + GitAgent
         │   ├── contracts.py #   Pydantic 模型：claims、证据、刷新状态
-        │   ├── ask_pipeline.py    # agent.md + 图谱增强问答
+        │   ├── ask_pipeline.py    # agent.md 路由问答
         │   ├── refresh_pipeline.py # LLM 驱动刷新 → agents/*.md + map.md
-        │   ├── ask_tools.py #   代码探索 + GitNexus 工具
+        │   ├── ask_tools.py #   代码探索工具
         │   ├── scanner.py   #   多语言项目扫描
         │   ├── module_grouping.py # 智能功能分组
         │   └── mcp_server.py#   MCP 服务端 (ag-mcp)
@@ -297,7 +295,7 @@ ag init my-project --force
 ag-refresh --workspace my-project
 ```
 
-**9 步流程：**
+**8 步流程：**
 1. 扫描代码库（语言、框架、结构）
 2. 多 Agent 管道生成 `conventions.md`
 3. 生成 `structure.md` —— 语言无关的文件树（含行数统计）
@@ -306,7 +304,6 @@ ag-refresh --workspace my-project
 6. **LLM 全量代码分析** —— 基于 import 图 + 目录 + 前缀分组，代码预加载进 context（每组约 30K tokens），自动过滤构建产物。每个 sub-agent 读取完整源码，输出**全面的 Markdown 知识文档**（`agents/*.md`）。大模块生成多个 agent 文档（每组一个，不合并）。全局 API 并发控制防止限流。**完全语言无关** —— 支持任何编程语言。
 7. **RefreshGitAgent** 分析 git 历史，生成 `_git_insights.md`
 8. **Map Agent** 读取所有 agent 文档 → 生成 `map.md`（模块路由索引，含描述和关键词）
-9. **GitNexus 索引**（可选）—— 运行 `gitnexus analyze` 构建 Tree-sitter 代码图谱（16 种语言，调用链、依赖关系）。未安装 GitNexus 时自动跳过。
 
 ### 3. `ag-ask` — Router 路由问答
 
@@ -314,9 +311,7 @@ ag-refresh --workspace my-project
 ag-ask "这个项目的认证逻辑是怎么实现的？"
 ```
 
-Ask 管道采用**双路架构**：
-- **语义路径**：Router 读取 `map.md` → 选择模块 → 读取 `agents/*.md` → LLM 回答并引用代码。多个 agent 文档由并行 LLM 读取，然后由 Synthesizer 合并答案。
-- **图谱路径**（自动）：Router LLM 判断问题是否需要结构分析 → 查询 GitNexus 获取调用链、依赖、影响范围 → 将图谱数据注入回答上下文。未安装 GitNexus 时静默跳过。
+Ask 管道采用**语义路径**：Router 读取 `map.md` → 选择模块 → 读取 `agents/*.md` → LLM 回答并引用代码。多个 agent 文档由并行 LLM 读取，然后由 Synthesizer 合并答案。
 
 若 agent 文档尚未生成，则回退到传统的 Router → ModuleAgent/GitAgent swarm 路径。
 
@@ -378,20 +373,18 @@ claude mcp add antigravity ag-mcp -- --workspace /path/to/project
  ag-refresh：                                ag-ask：
 
  对每个模块：                                Router（读 map.md）
- ┌ 按 import 图分组文件                        ├── GRAPH: no → 读 agents/*.md → LLM 回答
- ├ 每组预加载约 30K tokens                     └── GRAPH: yes → 查询 GitNexus 图谱
- ├ 自动过滤构建产物                                  → 图谱数据 + agents/*.md → LLM 回答
+ ┌ 按 import 图分组文件                        └── 读 agents/*.md → LLM 回答
+ ├ 每组预加载约 30K tokens
+ ├ 自动过滤构建产物
  ├ Sub-agent → Markdown agent 文档
  ├ agents/{module}.md（或 /group_N.md）
- ├ Map Agent → map.md
- └ GitNexus analyze（可选）
+ └ Map Agent → map.md
 ```
 
 **核心创新：**
 - **LLM 即分析器**：不使用 AST 解析或正则 —— 源码直接喂给 LLM 分析。开箱即用支持任何编程语言。
 - **智能分组**：基于 import 关系、目录共位、文件名前缀分组。构建产物自动过滤。字符硬限（800K）防止上下文溢出。
 - **零信息损失**：大模块生成多个 `agent.md`（每组一个）—— 不合并、不压缩。`ag-ask` 时多个 agent 文档由并行 LLM 读取，然后 Synthesizer 合并答案。
-- **图谱增强回答**：Router LLM 自动判断问题是否需要结构数据（调用链、依赖、影响范围），查询 GitNexus。将精确的图谱关系与语义理解结合。
 - **全局 API 并发控制**：`AG_API_CONCURRENCY` 限制所有模块的同时 LLM 调用数，防止限流。
 - **语言无关模块检测**：纯目录结构 —— 不需要 `__init__.py` 或任何语言特定标记。
 
@@ -435,50 +428,6 @@ ag log-decision "使用 PostgreSQL" "团队有丰富经验"
 自动连接外部 server 且信任这些 server 时，才设置 `AG_ALLOW_MCP=true`。
 Stdio MCP server 会继承进程环境变量和配置中的 `env` 值，因此应把它们视为拥有本地权限的代码。
 详见 [MCP 文档](docs/zh/MCP_INTEGRATION.md)。
-</details>
-
-<details>
-<summary><b>GitNexus 图谱增强</b> — 结构性问题的自动智能增强</summary>
-
-[GitNexus](https://github.com/abhigyanpatwari/GitNexus) 通过 **Tree-sitter AST 解析**构建代码知识图谱（支持 16 种语言）。安装后，Antigravity 在两个层面集成：
-
-**1. Refresh 时自动索引** —— `ag-refresh` 的第 9 步自动运行 `gitnexus analyze` 构建/更新代码图谱。未安装 GitNexus 时静默跳过。
-
-**2. Ask 时图谱增强** —— Router LLM 判断问题是否需要结构分析：
-- "认证模块做什么？" → `GRAPH: no` → 纯 agent.md 回答
-- "谁调用了 handleLogin？" → `GRAPH: yes` → 查询 GitNexus → 图谱数据 + agent.md → 增强回答
-
-```
-用户: "gateway 里哪些函数调用了 send 方法？"
-
-Router: MODULES: gateway, tests_gateway | GRAPH: yes
-  → GitNexus 返回调用链及置信度分数
-  → Agent 文档提供语义上下文（每个调用者做什么）
-  → 组合回答：精确调用链 + 文件路径 + 行号 + 用途说明
-```
-
-| 能力 | 提供内容 |
-|:-----|:---------|
-| `gitnexus_query` | 混合搜索（BM25 + 语义）—— 返回执行流而非仅文件 |
-| `gitnexus_context` | 符号 360° 视图：调用者、被调用者、引用、定义 |
-| `gitnexus_impact` | 变更爆炸半径分析 —— 修改一个符号会影响什么？ |
-
-> **注意：** GitNexus **不随** Antigravity 一起安装。需要通过 npm 单独安装（`npm install -g gitnexus`）。Antigravity 无需 GitNexus 即可完整运行 —— 未安装时所有图谱功能静默跳过，零开销。
-
-**启用方式：**
-
-```bash
-# 1. 安装 GitNexus（需要 Node.js）
-npm install -g gitnexus
-
-# 2. 刷新（自动索引代码图谱）
-ag-refresh --workspace my-project
-
-# 3. 提问 — 图谱增强自动生效
-ag-ask "谁调用了 gateway 适配器的 send 方法？"
-# Router 判断: GRAPH: yes → 查询 GitNexus → 增强回答
-```
-
 </details>
 
 <details>
@@ -619,7 +568,7 @@ Antigravity 在事实题上**比 Codex 快 2.1x**，在审计题上跟 Codex 速
         <img src="https://github.com/abhigyanpatwari.png" width="80" /><br/>
         <b>Abhigyan Patwari</b>
       </a><br/>
-      <sub><a href="https://github.com/abhigyanpatwari/GitNexus">GitNexus</a> — 代码知识图谱原生集成到 <code>ag ask</code>，提供符号搜索、调用图和影响分析</sub>
+      <sub>代码知识图谱原生集成到 <code>ag ask</code>，提供符号搜索、调用图和影响分析</sub>
     </td>
     <td align="center" width="20%">
       <a href="https://github.com/BBear0115">

--- a/README_ES.md
+++ b/README_ES.md
@@ -110,7 +110,7 @@ Tiempo: pocos minutos en repos pequeños, más en repos grandes. Requiere `ag-se
 
 ### `ag-ask` — Q&A enrutada sobre el código
 
-**La razón principal por la que existe este plugin**. Enruta tu pregunta al ModuleAgent adecuado (y a GitAgent / GitNexus cuando aplica), y devuelve una respuesta fundamentada en el código real, con rutas de archivo y números de línea. Úsalo **antes** de hacer grep manual o leer archivos — es más rápido y más preciso. Buenas formas de pregunta: "¿dónde se define/maneja X?", "¿por qué se hizo Y de esta forma?", "¿cómo funciona el flujo de auth?", "¿qué depende del módulo Z?".
+**La razón principal por la que existe este plugin**. Enruta tu pregunta al ModuleAgent adecuado (y a GitAgent cuando aplica), y devuelve una respuesta fundamentada en el código real, con rutas de archivo y números de línea. Úsalo **antes** de hacer grep manual o leer archivos — es más rápido y más preciso. Buenas formas de pregunta: "¿dónde se define/maneja X?", "¿por qué se hizo Y de esta forma?", "¿cómo funciona el flujo de auth?", "¿qué depende del módulo Z?".
 
 ```
 # Claude Code
@@ -212,11 +212,9 @@ ag init mi-proyecto && cd mi-proyecto
        └──► ag-mcp         Servidor MCP → Claude Code llama directamente
 ```
 
-**Clúster Multi-Agente Dinámico** — Durante `ag-refresh`, el motor usa **agrupación funcional inteligente**: archivos agrupados por relaciones de import, co-ubicación en directorios y prefijos de nombre. El código fuente se pre-carga directamente en el contexto del agente (sin tool calls), y los artefactos de build se filtran automáticamente. Cada sub-agente analiza ~30K tokens de código enfocado en 1 llamada LLM y produce un **documento de conocimiento Markdown completo** (`agents/*.md`). Módulos grandes generan múltiples agent docs en paralelo (uno por grupo, sin fusión ni pérdida de información). Un **Map Agent** lee todos los docs y genera `map.md` — un índice de enrutamiento. Durante `ag-ask`, Router lee `map.md` para seleccionar módulos relevantes, luego alimenta sus agent docs a los agentes de respuesta. Para preguntas estructurales (cadenas de llamadas, dependencias, análisis de impacto), el Router consulta automáticamente el grafo de código [GitNexus](https://github.com/abhigyanpatwari/GitNexus). **Completamente agnóstico al lenguaje** — detección de módulos por estructura de directorios pura, análisis de código realizado íntegramente por LLMs. Funciona con cualquier lenguaje de programación.
+**Clúster Multi-Agente Dinámico** — Durante `ag-refresh`, el motor usa **agrupación funcional inteligente**: archivos agrupados por relaciones de import, co-ubicación en directorios y prefijos de nombre. El código fuente se pre-carga directamente en el contexto del agente (sin tool calls), y los artefactos de build se filtran automáticamente. Cada sub-agente analiza ~30K tokens de código enfocado en 1 llamada LLM y produce un **documento de conocimiento Markdown completo** (`agents/*.md`). Módulos grandes generan múltiples agent docs en paralelo (uno por grupo, sin fusión ni pérdida de información). Un **Map Agent** lee todos los docs y genera `map.md` — un índice de enrutamiento. Durante `ag-ask`, Router lee `map.md` para seleccionar módulos relevantes, luego alimenta sus agent docs a los agentes de respuesta. **Completamente agnóstico al lenguaje** — detección de módulos por estructura de directorios pura, análisis de código realizado íntegramente por LLMs. Funciona con cualquier lenguaje de programación.
 
 **GitAgent** — Un agente dedicado a analizar el historial git — entiende quién cambió qué y por qué.
-
-**Enriquecimiento de Grafos GitNexus (opcional)** — Instala [GitNexus](https://github.com/abhigyanpatwari/GitNexus) para desbloquear respuestas enriquecidas con grafos. El Router LLM decide cuándo una pregunta necesita análisis estructural (cadenas de llamadas, dependencias, impacto) y consulta GitNexus automáticamente — combinando datos precisos del grafo con comprensión semántica de los agent docs.
 
 **Feedback de auditoría NLPM** — Este repositorio se ha beneficiado de [NLPM](https://github.com/xiaolai/nlpm-for-claude), un linter de programación en lenguaje natural para plugins de Claude Code, skills y definiciones de agentes creado por [xiaolai](https://github.com/xiaolai). Su auditoría ayudó a encontrar mejoras útiles en frontmatter de skills e higiene de dependencias.
 
@@ -255,7 +253,7 @@ antigravity-workspace-template/
         │   ├── contracts.py #   Modelos Pydantic: claims, evidencia, estado de refresh
         │   ├── ask_pipeline.py    # facts estructurados + swarm legacy
         │   ├── refresh_pipeline.py # orquestación de refresh basado en evidencia
-        │   ├── ask_tools.py #   Exploración de código + herramientas GitNexus
+        │   ├── ask_tools.py #   Exploración de código
         │   ├── scanner.py   #   Escaneo multi-lenguaje de proyecto
         │   ├── module_grouping.py # agrupación funcional inteligente
         │   └── mcp_server.py#   Servidor MCP (ag-mcp)
@@ -300,7 +298,7 @@ Crea `AGENTS.md` (reglas de comportamiento autoritativas), archivos bootstrap de
 ag-refresh --workspace mi-proyecto
 ```
 
-**Pipeline de 9 pasos:**
+**Pipeline de 8 pasos:**
 1. Escanear codebase (lenguajes, frameworks, estructura)
 2. Pipeline multi-agente genera `conventions.md`
 3. Generar `structure.md` — árbol de archivos agnóstico al lenguaje con conteos de líneas
@@ -309,7 +307,6 @@ ag-refresh --workspace mi-proyecto
 6. **Análisis completo por LLM** — archivos agrupados por grafo de imports + directorio + prefijo, pre-cargados en contexto (~30K tokens por sub-agente), artefactos de build filtrados automáticamente. Cada sub-agente lee el código fuente completo y produce un **documento de conocimiento Markdown completo** (`agents/*.md`). Módulos grandes generan múltiples agent docs (uno por grupo, sin fusión). Control global de concurrencia API previene rate-limiting. **Completamente agnóstico al lenguaje** — funciona con cualquier lenguaje de programación.
 7. **RefreshGitAgent** analiza historial git, genera `_git_insights.md`
 8. **Map Agent** lee todos los agent docs → genera `map.md` (índice de enrutamiento de módulos con descripciones y temas clave)
-9. **Indexación GitNexus** (opcional) — ejecuta `gitnexus analyze` para construir un grafo de código Tree-sitter (16 lenguajes, cadenas de llamadas, dependencias). Se omite automáticamente si GitNexus no está instalado.
 
 ### 3. `ag-ask` — Q&A basado en Router
 
@@ -317,9 +314,7 @@ ag-refresh --workspace mi-proyecto
 ag-ask "¿Cómo funciona la autenticación en este proyecto?"
 ```
 
-El pipeline de ask usa una **arquitectura de doble vía**:
-- **Vía semántica**: Router lee `map.md` → selecciona módulos → lee `agents/*.md` → LLM responde con referencias al código. Múltiples agent docs se leen en paralelo, luego un Synthesizer combina las respuestas.
-- **Vía de grafo** (automática): El Router LLM decide si la pregunta necesita análisis estructural → consulta GitNexus para cadenas de llamadas, dependencias o impacto → inyecta datos del grafo en el contexto. Se omite silenciosamente si GitNexus no está instalado.
+El pipeline de ask usa una **vía semántica**: Router lee `map.md` → selecciona módulos → lee `agents/*.md` → LLM responde con referencias al código. Múltiples agent docs se leen en paralelo, luego un Synthesizer combina las respuestas.
 
 Si los agent docs aún no se han generado, recurre al swarm legacy Router → ModuleAgent/GitAgent.
 
@@ -381,20 +376,18 @@ El núcleo del motor es **un clúster de Agents creado dinámicamente por módul
  ag-refresh:                                 ag-ask:
 
  Para cada módulo:                           Router (lee map.md)
- ┌ Agrupar archivos por grafo de imports       ├── GRAPH: no → leer agents/*.md → respuesta LLM
- ├ Pre-cargar ~30K tokens por sub-agente       └── GRAPH: yes → consultar grafo GitNexus
- ├ Filtrar artefactos de build                       → datos de grafo + agents/*.md → respuesta LLM
+ ┌ Agrupar archivos por grafo de imports       └── leer agents/*.md → respuesta LLM
+ ├ Pre-cargar ~30K tokens por sub-agente
+ ├ Filtrar artefactos de build
  ├ Sub-agentes → documentos Markdown agent
  ├ agents/{module}.md (o /group_N.md)
- ├ Map Agent → map.md
- └ GitNexus analyze (opcional)
+ └ Map Agent → map.md
 ```
 
 **Innovaciones clave:**
 - **LLM como analizador**: Sin AST ni regex — el código fuente se alimenta directamente al LLM. Funciona con cualquier lenguaje de programación de forma inmediata.
 - **Agrupación inteligente**: Archivos agrupados por relaciones de import, co-ubicación en directorios y prefijos de nombre. Artefactos de build filtrados automáticamente. Límite duro de caracteres (800K) previene desbordamiento de contexto.
 - **Sin pérdida de información**: Módulos grandes producen múltiples `agent.md` (uno por grupo) — sin fusión ni compresión. Durante `ag-ask`, múltiples agent docs son leídos por LLMs en paralelo, luego un Synthesizer combina las respuestas.
-- **Respuestas enriquecidas con grafos**: El Router LLM decide automáticamente cuándo una pregunta necesita datos estructurales (cadenas de llamadas, dependencias, impacto) y consulta GitNexus. Combina relaciones precisas del grafo con comprensión semántica.
 - **Control global de concurrencia API**: `AG_API_CONCURRENCY` limita las llamadas LLM simultáneas entre todos los módulos, previniendo rate-limiting.
 - **Detección de módulos agnóstica al lenguaje**: Estructura de directorios pura — sin `__init__.py` ni marcadores específicos de lenguaje.
 
@@ -441,34 +434,6 @@ Configura `MCP_ENABLED=true` para hacer visibles los servidores y
 automáticamente. Los servidores MCP por stdio heredan el entorno del proceso y
 los valores `env` configurados, así que trátalos como código con permisos
 locales.
-</details>
-
-<details>
-<summary><b>Integración GitNexus</b> — Inteligencia profunda de código opcional</summary>
-
-[GitNexus](https://github.com/abhigyanpatwari/GitNexus) es una **herramienta de terceros** que construye un grafo de conocimiento de código usando Tree-sitter AST. Antigravity proporciona hooks de integración incorporados — cuando instalas GitNexus por separado, `ag-ask` lo detecta automáticamente y desbloquea tres herramientas adicionales:
-
-| Herramienta | Función |
-|:------------|:--------|
-| `gitnexus_query` | Búsqueda híbrida (BM25 + semántica) — superior a grep para consultas semánticas |
-| `gitnexus_context` | Vista 360° de un símbolo: llamadores, llamados, referencias, definición |
-| `gitnexus_impact` | Análisis de radio de explosión — ¿qué se rompe si cambias un símbolo? |
-
-> **Nota:** GitNexus **NO** viene incluido con Antigravity. Antigravity funciona completamente sin él — GitNexus es una mejora opcional.
-
-```bash
-# 1. Instalar GitNexus (requiere Node.js)
-npm install -g gitnexus
-
-# 2. Indexar tu proyecto
-cd my-project
-gitnexus analyze .
-
-# 3. Usar ag-ask como siempre — las herramientas GitNexus se detectan automáticamente
-ag-ask "¿Cómo funciona el flujo de autenticación?"
-```
-
-**Cómo funciona:** `ask_tools.py` verifica si el CLI `gitnexus` está. Si lo encuentra, registra las herramientas para cada ModuleAgent. Si no, simplemente no aparecen — cero overhead.
 </details>
 
 <details>
@@ -595,13 +560,6 @@ Reporte completo (datos, metodología, tablas por celda, advertencias):
         <b>goodmorning10</b>
       </a><br/>
       <sub>Mejora de carga de contexto en <code>ag ask</code> — añadió CONTEXT.md, AGENTS.md y memory/*.md como fuentes de contexto (#29)</sub>
-    </td>
-    <td align="center" width="20%">
-      <a href="https://github.com/abhigyanpatwari">
-        <img src="https://github.com/abhigyanpatwari.png" width="80" /><br/>
-        <b>Abhigyan Patwari</b>
-      </a><br/>
-      <sub><a href="https://github.com/abhigyanpatwari/GitNexus">GitNexus</a> — grafo de conocimiento de código integrado nativamente en <code>ag ask</code> para búsqueda de símbolos, grafos de llamadas y análisis de impacto</sub>
     </td>
     <td align="center" width="20%">
       <a href="https://github.com/BBear0115">

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -20,6 +20,3 @@ ag = "ag_cli.cli:app"
 # ── Hatch build configuration ──────────────────────────────────────
 [tool.hatch.build.targets.wheel]
 packages = ["src/ag_cli"]
-
-[tool.hatch.build.targets.wheel.force-include]
-"src/ag_cli/templates" = "ag_cli/templates"

--- a/docs/assets/demo-mock.sh
+++ b/docs/assets/demo-mock.sh
@@ -16,19 +16,19 @@ c_off="\033[0m"
 echo
 
 if [[ "$QUESTION" == *"calls"* || "$QUESTION" == *"call "* ]]; then
-  printf "${c_cyan}▸ Router: GRAPH=yes → querying GitNexus call chain${c_off}\n"
+  printf "${c_cyan}▸ Router: selecting relevant modules → refresh_pipeline${c_off}\n"
   sleep 0.5
   printf "${c_cyan}▸ Reading agents/refresh_pipeline.md${c_off}\n"
   sleep 0.4
   echo
-  printf "${c_green}✓ Answer (graph + 2 sources):${c_off}\n"
+  printf "${c_green}✓ Answer (2 sources):${c_off}\n"
   echo
   echo "  refresh_pipeline.run() is called from:"
   echo
   printf "    1. _cli_entry.ag_refresh()             ${c_under}engine/antigravity_engine/_cli_entry.py:142${c_off}\n"
   printf "    2. mcp_server.refresh_project()        ${c_under}engine/antigravity_engine/hub/mcp_server.py:88${c_off}\n"
   echo
-  printf "  ${c_dim}Confidence: high · Tree-sitter parse + agent doc cross-check${c_off}\n"
+  printf "  ${c_dim}Confidence: high · agent doc + live source cross-check${c_off}\n"
   echo
   exit 0
 fi

--- a/engine/antigravity_engine/hub/_constants.py
+++ b/engine/antigravity_engine/hub/_constants.py
@@ -138,3 +138,15 @@ FRAMEWORK_MARKERS: dict[str, str] = {
     "setup.cfg": "Python (setup.cfg)",
     "tox.ini": "Tox",
 }
+
+# ---------------------------------------------------------------------------
+# Fallback knowledge-doc markers
+# ---------------------------------------------------------------------------
+
+# Written at the top / in the body of an auto-generated fallback agent.md.
+# A fallback doc is emitted when a module's LLM analysis fails or times out and
+# contains only a bare file listing — NOT real analyzed knowledge. The ask
+# pipeline detects either marker so a degraded module is never silently served
+# as if it were factual, grounded knowledge.
+AGENT_MD_FALLBACK_MARKER = "<!-- ag:status=fallback -->"
+AGENT_MD_FALLBACK_SENTINEL = "(Auto-generated fallback — LLM analysis was unavailable)"

--- a/engine/antigravity_engine/hub/ask_pipeline.py
+++ b/engine/antigravity_engine/hub/ask_pipeline.py
@@ -14,7 +14,11 @@ import subprocess
 import sys
 from pathlib import Path
 
-from antigravity_engine.hub._constants import SKIP_DIRS
+from antigravity_engine.hub._constants import (
+    AGENT_MD_FALLBACK_MARKER,
+    AGENT_MD_FALLBACK_SENTINEL,
+    SKIP_DIRS,
+)
 from antigravity_engine.hub.contracts import (
     ClaimVerification,
     ModuleClaim,
@@ -400,13 +404,12 @@ async def _ask_with_structured_facts(workspace: Path, question: str) -> str | No
     return await _ask_with_legacy_facts(workspace, question)
 
 
-def _parse_router_output(output: str) -> tuple[list[str], bool]:
+def _parse_router_output(output: str) -> list[str]:
     """Parse the Router agent's structured output.
 
     Expected format::
 
         MODULES: module1, module2
-        GRAPH: yes
 
     Falls back to treating each line as a module name if the format
     is not recognized (backward compatible with old Router output).
@@ -415,61 +418,25 @@ def _parse_router_output(output: str) -> tuple[list[str], bool]:
         output: Raw Router agent output text.
 
     Returns:
-        Tuple of (raw module name list, needs_graph boolean).
+        List of raw module names.
     """
     modules: list[str] = []
-    needs_graph = False
 
     for line in output.splitlines():
         stripped = line.strip()
-        upper = stripped.upper()
-
-        if upper.startswith("MODULES:"):
+        if stripped.upper().startswith("MODULES:"):
             raw = stripped[len("MODULES:"):].strip()
             modules = [m.strip().strip("`*") for m in raw.split(",") if m.strip()]
-        elif upper.startswith("GRAPH:"):
-            val = stripped[len("GRAPH:"):].strip().lower()
-            needs_graph = val in ("yes", "true", "1")
 
     # Fallback: if no MODULES: line found, treat each line as a module name
     if not modules:
         modules = [
             line.strip().strip("- *`#")
             for line in output.strip().splitlines()
-            if line.strip() and not line.strip().upper().startswith("GRAPH:")
+            if line.strip()
         ]
 
-    return modules, needs_graph
-
-
-def _query_graph_for_question(workspace: Path, question: str) -> str:
-    """Query GitNexus code knowledge graph for structural information.
-
-    Calls ``gitnexus query`` with the user's question to get call chains,
-    dependency relationships, and symbol context. Silently returns empty
-    string if GitNexus is not installed or not indexed.
-
-    Args:
-        workspace: Project root directory.
-        question: Natural language question.
-
-    Returns:
-        Graph query results as formatted string, or empty string.
-    """
-    from antigravity_engine.hub.ask_tools import (
-        _is_gitnexus_available,
-        _run_gitnexus,
-    )
-
-    if not _is_gitnexus_available():
-        return ""
-
-    # Use gitnexus query for hybrid search (BM25 + semantic)
-    result = _run_gitnexus(workspace.resolve(), ["query", question])
-    if not result or "error" in result.lower()[:50]:
-        return ""
-
-    return result
+    return modules
 
 
 def _match_to_known_modules(
@@ -598,6 +565,28 @@ def _load_project_context(
     return "## Project Context (project-wide reference docs)\n\n" + "\n\n".join(parts)
 
 
+def _is_fallback_doc(content: str) -> bool:
+    """True if an agent.md is an auto-generated refresh fallback (a bare file
+    listing written when a module's LLM analysis failed), not real knowledge."""
+    return AGENT_MD_FALLBACK_MARKER in content or AGENT_MD_FALLBACK_SENTINEL in content
+
+
+def _prepend_degradation_banner(
+    answer: str | None, degraded_modules: list[str]
+) -> str | None:
+    """Prefix a visible warning when some answered modules had only fallback
+    (un-analyzed) knowledge, so an answer is never presented as fully grounded."""
+    if not answer or not degraded_modules:
+        return answer
+    mods = ", ".join(degraded_modules)
+    banner = (
+        f"> ⚠ Incomplete knowledge for module(s): {mods}. These were not fully "
+        "analyzed in the last refresh, so the answer may be unreliable for them — "
+        "run `ag-refresh --failed-only` to fix.\n\n"
+    )
+    return banner + answer
+
+
 async def _ask_with_agent_md(workspace: Path, question: str) -> str | None:
     """Answer a question by routing through map.md → agent.md files.
 
@@ -646,23 +635,11 @@ async def _ask_with_agent_md(workspace: Path, question: str) -> str | None:
     router_prompt = f"""\
 You are a routing agent for a codebase Q&A system.
 
-Given the question and module map below, do TWO things:
-
-1. Select 1-3 modules most relevant to this question.
-2. Decide whether this question needs **structural graph analysis** — i.e.,
-   call chains, dependency graphs, import relationships, impact analysis,
-   cross-module data flow, or symbol lookup. If the question is about
-   WHAT code does or WHY it's designed that way, graph is NOT needed.
-   If it's about WHO calls WHOM, dependencies, or tracing execution flow,
-   graph IS needed.
+Given the question and module map below, select the 1-3 modules most relevant
+to this question.
 
 Output format (strict):
 MODULES: module1, module2
-GRAPH: yes
-
-Or:
-MODULES: module1
-GRAPH: no
 
 Question: {question}
 
@@ -671,7 +648,7 @@ Module Map:
 """
     router_agent = Agent(
         name="QuickRouter",
-        instructions="Output ONLY in the exact format: MODULES: ... and GRAPH: yes/no. No other text.",
+        instructions="Output ONLY in the exact format: MODULES: module1, module2. No other text.",
         model=model,
     )
     ask_timeout = float(os.environ.get("AG_ASK_TIMEOUT_SECONDS", "240"))
@@ -684,11 +661,12 @@ Module Map:
             stream_enabled=settings.STREAM_ENABLED,
             progress_label="Routing question via map.md...",
         )
-    except Exception:
+    except Exception as exc:
+        logger.warning("ask: router agent failed: %s", exc)
         return None
 
-    # Parse Router output: MODULES + GRAPH decision
-    raw_modules, needs_graph = _parse_router_output(router_output)
+    # Parse Router output: MODULES line
+    raw_modules = _parse_router_output(router_output)
 
     # Collect known module names from agents/ directory
     agents_dir = ag_dir / "agents"
@@ -702,10 +680,13 @@ Module Map:
 
     selected_modules = _match_to_known_modules(raw_modules, known_modules)
     if not selected_modules:
+        logger.warning(
+            "ask: router output matched no known modules (raw=%s)", raw_modules
+        )
         return None
 
     print(
-        f"[2/4] Selected modules: {', '.join(selected_modules)} | graph: {'yes' if needs_graph else 'no'}",
+        f"[2/4] Selected modules: {', '.join(selected_modules)}",
         file=sys.stderr,
     )
 
@@ -730,16 +711,26 @@ Module Map:
                     continue
 
     if not module_knowledge:
+        logger.warning(
+            "ask: selected modules had no readable agent docs: %s", selected_modules
+        )
         return None
 
-    # Step 2.5: Query GitNexus graph if Router decided it's needed
-    graph_context = ""
-    if needs_graph:
-        graph_context = _query_graph_for_question(workspace, question)
-        if graph_context:
-            print(f"[2.5/4] Graph enrichment: {len(graph_context)} chars", file=sys.stderr)
+    # Detect modules whose knowledge doc is an auto-generated refresh fallback
+    # (a bare file listing, not real analysis) so it is never silently served
+    # to the user as factual, grounded knowledge.
+    degraded_modules = [
+        name for name, content in module_knowledge if _is_fallback_doc(content)
+    ]
+    if degraded_modules:
+        logger.warning(
+            "ask: %d selected module doc(s) are refresh fallbacks (no LLM "
+            "analysis): %s",
+            len(degraded_modules),
+            ", ".join(degraded_modules),
+        )
 
-    # Step 2.6: Load project-level docs so the synthesizer can answer
+    # Step 2.5: Load project-level docs so the synthesizer can answer
     # project-wide questions (conventions, CI, dependencies, module
     # relationships) even when per-module agent docs don't carry them.
     project_context = _load_project_context(ag_dir, map_content=map_content)
@@ -754,22 +745,20 @@ tooling, lint/format/type-check, CI, docs, dependencies, supported environments,
 or how modules relate to each other. If the project context already answers the
 question, answer from it even if the per-module knowledge does not."""
 
-    # Step 3: Answer from agent.md content (+ optional graph context)
+    if degraded_modules:
+        project_section += (
+            "\n\nIMPORTANT: The knowledge for these module(s) is an auto-generated "
+            "fallback — a bare file listing, NOT real analysis: "
+            f"{', '.join(degraded_modules)}. Do not present that file list as findings. "
+            "Use the code-inspection tools to read the listed files directly; if you "
+            "cannot ground the answer in real source, say the module knowledge is "
+            "incomplete."
+        )
+
+    # Step 3: Answer from agent.md content
     print(f"[3/4] Reading {len(module_knowledge)} agent docs...", file=sys.stderr)
     ask_api_concurrency = int(os.environ.get("AG_API_CONCURRENCY", "5"))
     _ask_api_sem = asyncio.Semaphore(ask_api_concurrency)
-
-    # Build graph section for prompts (empty string if no graph data)
-    graph_section = ""
-    if graph_context:
-        graph_section = f"""
-
-Structural relationships (from code knowledge graph — precise call/import/dependency data):
-{graph_context[:30_000]}
-
-IMPORTANT: The "module knowledge" describes WHAT the code does (semantic understanding).
-The "structural relationships" show WHO calls/imports WHOM (precise graph data).
-Combine both sources for a complete answer. Prefer graph data for structural questions."""
 
     if len(module_knowledge) == 1:
         # Single agent.md → one LLM call
@@ -802,7 +791,6 @@ Question: {question}
 Module: {mod_name}
 Knowledge:
 {knowledge[:80_000]}
-{graph_section}
 """
         answer_agent = Agent(
             name="AnswerAgent",
@@ -822,8 +810,9 @@ Knowledge:
                 progress_label="Generating answer from agent.md...",
             )
             print("[4/4] Answer synthesized.", file=sys.stderr)
-            return answer
-        except Exception:
+            return _prepend_degradation_banner(answer, degraded_modules)
+        except Exception as exc:
+            logger.warning("ask: answer agent failed: %s", exc)
             return None
     else:
         # Multiple agent.md → parallel LLM calls (with concurrency limit) → synthesizer
@@ -855,7 +844,6 @@ Question: {question}
 Module: {mod_name}
 Knowledge:
 {knowledge[:60_000]}
-{graph_section}
 """
             agent = Agent(
                 name=f"Reader_{mod_name}",
@@ -876,7 +864,8 @@ Knowledge:
                         progress_label=None,
                     )
                 return mod_name, answer
-            except Exception:
+            except Exception as exc:
+                logger.warning("ask: reader for module %s failed: %s", mod_name, exc)
                 return mod_name, None
 
         partial_answers = await asyncio.gather(
@@ -892,11 +881,12 @@ Knowledge:
         ]
 
         if not valid_answers:
+            logger.warning("ask: no per-module reader produced a usable answer")
             return None
 
         if len(valid_answers) == 1:
             print("[4/4] Answer synthesized.", file=sys.stderr)
-            return valid_answers[0][1]
+            return _prepend_degradation_banner(valid_answers[0][1], degraded_modules)
 
         # Synthesize multiple answers
         synth_parts = "\n\n---\n\n".join(
@@ -929,10 +919,11 @@ Partial answers:
                 progress_label="Synthesizing answers from multiple modules...",
             )
             print("[4/4] Answer synthesized from multiple modules.", file=sys.stderr)
-            return answer
-        except Exception:
+            return _prepend_degradation_banner(answer, degraded_modules)
+        except Exception as exc:
+            logger.warning("ask: multi-module synthesis failed: %s", exc)
             # Return the first valid answer as fallback
-            return valid_answers[0][1]
+            return _prepend_degradation_banner(valid_answers[0][1], degraded_modules)
 
 
 async def _ask_with_legacy_facts(workspace: Path, question: str) -> str | None:

--- a/engine/antigravity_engine/hub/ask_tools.py
+++ b/engine/antigravity_engine/hub/ask_tools.py
@@ -32,108 +32,6 @@ _MAX_READ_LINES = 200
 
 
 # ---------------------------------------------------------------------------
-# GitNexus integration (optional)
-# ---------------------------------------------------------------------------
-
-def _is_gitnexus_available() -> bool:
-    """Check if the ``gitnexus`` CLI is installed and reachable."""
-    try:
-        subprocess.run(
-            ["gitnexus", "--version"],
-            capture_output=True,
-            timeout=5,
-            check=False,
-        )
-        return True
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        return False
-
-
-def _run_gitnexus(workspace: Path, args: list[str], timeout: int = 30) -> str:
-    """Run a gitnexus CLI command and return stdout.
-
-    Args:
-        workspace: Project root.
-        args: CLI arguments after ``gitnexus``.
-        timeout: Seconds before giving up.
-
-    Returns:
-        stdout text, or an error string.
-    """
-    try:
-        result = subprocess.run(
-            ["gitnexus", *args],
-            capture_output=True,
-            text=True,
-            cwd=str(workspace),
-            timeout=timeout,
-            check=False,
-        )
-        if result.returncode != 0:
-            err = result.stderr.strip() or "unknown error"
-            return f"GitNexus error: {err}"
-        return result.stdout.strip() or "(no output)"
-    except FileNotFoundError:
-        return "GitNexus is not installed."
-    except subprocess.TimeoutExpired:
-        return "GitNexus query timed out."
-
-
-def _create_gitnexus_tools(workspace: Path) -> dict[str, Callable]:
-    """Create GitNexus-powered tools if gitnexus is installed.
-
-    Args:
-        workspace: Absolute path to the project root.
-
-    Returns:
-        Dict of tool-name to callable, empty if gitnexus unavailable.
-    """
-    if not _is_gitnexus_available():
-        return {}
-
-    ws = workspace.resolve()
-
-    def gitnexus_query(query: str) -> str:
-        """Search the project's code knowledge graph using hybrid search.
-
-        Args:
-            query: Natural-language or symbol-name query.
-
-        Returns:
-            Ranked search results with file paths, symbols, and context.
-        """
-        return _run_gitnexus(ws, ["query", query])
-
-    def gitnexus_context(symbol: str) -> str:
-        """Get a 360-degree view of a symbol: definition, callers, callees, and references.
-
-        Args:
-            symbol: Fully-qualified or short symbol name.
-
-        Returns:
-            Symbol definition, categorized references, and relationships.
-        """
-        return _run_gitnexus(ws, ["context", symbol])
-
-    def gitnexus_impact(symbol: str) -> str:
-        """Analyze the blast radius of changing a symbol.
-
-        Args:
-            symbol: The symbol to analyze impact for.
-
-        Returns:
-            Impact analysis with affected files and confidence scores.
-        """
-        return _run_gitnexus(ws, ["impact", symbol])
-
-    return {
-        "gitnexus_query": gitnexus_query,
-        "gitnexus_context": gitnexus_context,
-        "gitnexus_impact": gitnexus_impact,
-    }
-
-
-# ---------------------------------------------------------------------------
 # Tool factory — returns workspace-bound tool functions
 # ---------------------------------------------------------------------------
 
@@ -475,10 +373,6 @@ def create_ask_tools(workspace: Path) -> dict[str, Callable]:
         "summarize_directory": summarize_directory,
         "read_binary_stub": read_binary_stub,
     }
-
-    # ── GitNexus tools (optional) ──
-    gitnexus_tools = _create_gitnexus_tools(ws)
-    tools.update(gitnexus_tools)
 
     # Every retrieval call emits a lossless graph artifact.
     return wrap_retrieval_tools(ws, tools)

--- a/engine/antigravity_engine/hub/refresh_pipeline.py
+++ b/engine/antigravity_engine/hub/refresh_pipeline.py
@@ -17,7 +17,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from antigravity_engine.hub._constants import SOURCE_CODE_EXTS, WORKSPACE_ROOT_MODULE_ID
+from antigravity_engine.hub._constants import (
+    AGENT_MD_FALLBACK_MARKER,
+    AGENT_MD_FALLBACK_SENTINEL,
+    SOURCE_CODE_EXTS,
+    WORKSPACE_ROOT_MODULE_ID,
+)
 from antigravity_engine.hub.contracts import (
     EvidenceSpan,
     FailureRecord,
@@ -672,19 +677,12 @@ async def refresh_pipeline(workspace: Path, quick: bool = False, failed_only: bo
         print("[8/8] Scan-only mode: map generation skipped.", file=sys.stderr)
         refresh_status.stages["module_registry"] = "skipped"
 
-    # -- Step 9: GitNexus code graph indexing (optional) --
-    _run_gitnexus_analyze(workspace, refresh_status)
-
     current_sha = _get_head_sha(workspace)
     if current_sha:
         sha_file.write_text(current_sha, encoding="utf-8")
 
-    # GitNexus is optional — exclude it from overall status calculation
-    non_optional_stages = {
-        k: v for k, v in refresh_status.stages.items() if k != "gitnexus"
-    }
     refresh_status.overall_status = _aggregate_states(
-        list(non_optional_stages.values()) + list(refresh_status.modules.values()),
+        list(refresh_status.stages.values()) + list(refresh_status.modules.values()),
         skipped_state="success",
     )
     _write_refresh_status(ag_dir, refresh_status)
@@ -1373,9 +1371,10 @@ def _build_agent_md_fallback(
         Markdown string with file listing.
     """
     lines = [
+        AGENT_MD_FALLBACK_MARKER,
         f"# Module: {module} — Group: {group_name}",
         "",
-        "(Auto-generated fallback — LLM analysis was unavailable)",
+        AGENT_MD_FALLBACK_SENTINEL,
         "",
         "## Source Files",
         "",
@@ -1716,72 +1715,6 @@ def _export_normalized_graph_store(ag_dir: Path, graph: dict[str, Any]) -> None:
         ("\n".join(edges_lines) + "\n") if edges_lines else "",
         encoding="utf-8",
     )
-
-
-def _run_gitnexus_analyze(workspace: Path, refresh_status: RefreshStatus) -> None:
-    """Run ``gitnexus analyze`` to build/update the code knowledge graph.
-
-    Silently skips if the ``gitnexus`` CLI is not installed. This step is
-    optional — the ask pipeline degrades gracefully without it.
-
-    Args:
-        workspace: Project root directory.
-        refresh_status: Mutable refresh status to record outcome.
-    """
-    try:
-        result = subprocess.run(
-            ["gitnexus", "--version"],
-            capture_output=True,
-            check=False,
-        )
-        if result.returncode != 0:
-            print("[9/9] GitNexus not installed; skipping code graph indexing.", file=sys.stderr)
-            refresh_status.stages["gitnexus"] = "skipped"
-            return
-    except FileNotFoundError:
-        print("[9/9] GitNexus not installed; skipping code graph indexing.", file=sys.stderr)
-        refresh_status.stages["gitnexus"] = "skipped"
-        return
-
-    print("[9/9] Running GitNexus code graph indexing...", file=sys.stderr)
-    try:
-        gitnexus_timeout = int(os.environ.get("AG_GITNEXUS_TIMEOUT_SECONDS", "300"))
-        result = subprocess.run(
-            ["gitnexus", "analyze", str(workspace.resolve())],
-            capture_output=True,
-            text=True,
-            cwd=str(workspace),
-            check=False,
-            timeout=gitnexus_timeout,
-        )
-        if result.returncode == 0:
-            print("  ✓ GitNexus code graph indexed", file=sys.stderr)
-            refresh_status.stages["gitnexus"] = "success"
-        else:
-            stderr_snippet = (result.stderr or "")[:200].strip()
-            print(f"  ⚠ GitNexus analyze failed: {stderr_snippet}", file=sys.stderr)
-            _mark_stage_failure(
-                refresh_status,
-                stage="gitnexus",
-                reason=stderr_snippet or "non-zero exit code",
-                partial=True,
-            )
-    except subprocess.TimeoutExpired:
-        print("  ⚠ GitNexus analyze timed out", file=sys.stderr)
-        _mark_stage_failure(
-            refresh_status,
-            stage="gitnexus",
-            reason="timeout",
-            partial=True,
-        )
-    except Exception as exc:
-        print(f"  ⚠ GitNexus analyze error: {exc}", file=sys.stderr)
-        _mark_stage_failure(
-            refresh_status,
-            stage="gitnexus",
-            reason=str(exc),
-            partial=True,
-        )
 
 
 def _get_head_sha(workspace: Path) -> str | None:

--- a/engine/tests/test_ask_fallback_detection.py
+++ b/engine/tests/test_ask_fallback_detection.py
@@ -1,0 +1,56 @@
+"""Regression tests for fallback-knowledge detection on the ask path.
+
+When a module's LLM analysis fails during refresh, ``_build_agent_md_fallback``
+writes a bare file listing instead of real knowledge. The ask path must detect
+these degraded docs so they are never silently presented as factual, grounded
+answers. These tests pin that contract.
+"""
+
+from __future__ import annotations
+
+import types
+
+from antigravity_engine.hub._constants import (
+    AGENT_MD_FALLBACK_MARKER,
+    AGENT_MD_FALLBACK_SENTINEL,
+)
+from antigravity_engine.hub.ask_pipeline import (
+    _is_fallback_doc,
+    _prepend_degradation_banner,
+)
+from antigravity_engine.hub.refresh_pipeline import _build_agent_md_fallback
+
+
+def _stub_group() -> types.SimpleNamespace:
+    source_file = types.SimpleNamespace(
+        content="line1\nline2\n", rel_path="pkg/mod.py", language="Python"
+    )
+    return types.SimpleNamespace(files=[source_file])
+
+
+def test_fallback_doc_is_marked_and_detected() -> None:
+    md = _build_agent_md_fallback("modA", "g0", _stub_group())
+    assert AGENT_MD_FALLBACK_MARKER in md
+    assert AGENT_MD_FALLBACK_SENTINEL in md
+    assert _is_fallback_doc(md) is True
+
+
+def test_real_doc_not_detected_as_fallback() -> None:
+    real = "# Module: auth\n\nHandles authentication via JWT, see `auth.py:42`.\n"
+    assert _is_fallback_doc(real) is False
+
+
+def test_legacy_sentinel_only_doc_is_detected() -> None:
+    # Fallback docs generated before the marker existed still carry the sentinel.
+    legacy = f"# Module: x\n\n{AGENT_MD_FALLBACK_SENTINEL}\n"
+    assert _is_fallback_doc(legacy) is True
+
+
+def test_degradation_banner_only_when_degraded() -> None:
+    assert _prepend_degradation_banner("answer", []) == "answer"
+    assert _prepend_degradation_banner(None, ["m"]) is None
+    out = _prepend_degradation_banner("answer", ["modA"])
+    assert out is not None
+    assert out.startswith(">")
+    assert "modA" in out
+    assert out.endswith("answer")

--- a/engine/tests/test_plugin_packaging.py
+++ b/engine/tests/test_plugin_packaging.py
@@ -88,7 +88,14 @@ def test_legacy_unprefixed_mcp_tool_names_do_not_reappear() -> None:
         "__pycache__",
         "venv",
         ".venv",
+        ".tmp-venv",
         "antigravity_workspace_template_venv",
+        # Generated / local-only dirs that are never part of shipped source:
+        # the knowledge base, IDE & agent state, eval artifacts, build output.
+        ".antigravity",
+        ".claude",
+        "artifacts",
+        "build",
     }
     searchable_suffixes = {".md", ".json", ".py", ".toml"}
     this_file = Path(__file__).resolve()

--- a/mcp_servers.json
+++ b/mcp_servers.json
@@ -75,15 +75,6 @@
       }
     },
     {
-      "name": "gitnexus",
-      "description": "Code knowledge graph — symbol search, call graphs, impact analysis (requires: npm install -g gitnexus && gitnexus analyze .)",
-      "transport": "stdio",
-      "command": "gitnexus",
-      "args": ["mcp"],
-      "enabled": false,
-      "env": {}
-    },
-    {
       "name": "custom-http",
       "description": "Example HTTP/Streamable HTTP server",
       "transport": "http",

--- a/mission.md
+++ b/mission.md
@@ -16,7 +16,3 @@ Antigravity centers on the `ag-refresh` + `ag-ask` workflow:
 - Other IDEs can use the shared context files, raw CLI commands, or `ag-mcp`.
 - Documentation, version metadata, and CI checks describe the same product
   contract.
-
-## Note
-For a generated downstream project, replace this file with that project's own
-mission.


### PR DESCRIPTION
## What

Two cleanups in one pass.

### 1. Remove the optional GitNexus integration (zero dependency, zero mention)
- **ask_tools.py** — drop `_create_gitnexus_tools` + the `gitnexus` CLI helpers (live code-inspection tools kept)
- **ask_pipeline.py** — drop `_query_graph_for_question` and the `needs_graph` / `GRAPH:` router decision + `graph_section` prompt injection. **Module routing and the project's own internal `query_graph` skill / `knowledge_graph.json` / `.antigravity/graph` are untouched** (those are not GitNexus).
- **refresh_pipeline.py** — drop the Step 9 `gitnexus analyze` stage + its status handling
- **README.md / README_CN.md / README_ES.md / mcp_servers.json / docs/assets/demo-mock.sh** — remove GitNexus sections/server/links

### 2. Close two silent-failure holes on the ask path
- **Fallback knowledge served as fact** — when a module's refresh analysis fails, `_build_agent_md_fallback` writes a bare file listing; the ask path previously read it as real knowledge. Now it's tagged (`<!-- ag:status=fallback -->`), detected at answer time, surfaced with a visible banner, and the answer is steered to live-source grounding. Regression test added (`test_ask_fallback_detection.py`).
- **Silent `except: return None`** — added `logger.warning` before the previously silent degrade points on the ask hot path.

### Also
- Remove the broken README hero `demo.gif` reference (file didn't exist; `before_after.png` now leads)
- Delete the stale `mission.md` "downstream project" template note
- Scope the legacy-MCP-name packaging test to real source (skip generated/local dirs like `.antigravity`, `.claude`, `artifacts`, `build`)

## Tests
`219 passed` (full engine suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)