### PR TITLE
Fix grouping for top-level static modules

### DIFF
--- a/engine/antigravity_engine/hub/module_grouping.py
+++ b/engine/antigravity_engine/hub/module_grouping.py
@@ -154,7 +154,7 @@ def load_module_files(module_path: Path, workspace: Path) -> list[SourceFile]:
             continue
         if fpath.suffix.lower() not in SOURCE_EXTENSIONS:
             continue
-        if _is_artifact(fpath):
+        if _is_artifact(fpath, module_path):
             continue
 
         try:
@@ -192,13 +192,19 @@ def load_module_files(module_path: Path, workspace: Path) -> list[SourceFile]:
     return files
 
 
-def _is_artifact(fpath: Path) -> bool:
+def _is_artifact(fpath: Path, module_path: Path | None = None) -> bool:
     """Check if a file is a build artifact that should be skipped.
 
     Checks directory names, file patterns, and heuristics for
     generated/bundled/compiled files.
     """
-    parts = fpath.parts
+    if module_path is not None:
+        try:
+            parts = fpath.relative_to(module_path).parts
+        except ValueError:
+            parts = fpath.parts
+    else:
+        parts = fpath.parts
     fname = fpath.name.lower()
 
     # Directory-based: any parent dir is an artifact directory

--- a/engine/tests/test_hub_module_grouping.py
+++ b/engine/tests/test_hub_module_grouping.py
@@ -60,6 +60,24 @@ def test_load_module_files_limits_workspace_root_to_direct_files(tmp_path: Path)
     assert [item.rel_path for item in loaded] == ["main.go"]
 
 
+def test_load_module_files_keeps_top_level_static_source_module(tmp_path: Path) -> None:
+    """A real top-level static/ source module should not be treated as an artifact."""
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "app.js").write_text("export function run() { return true; }\n", encoding="utf-8")
+
+    nested_static = static_dir / "nested" / "static"
+    nested_static.mkdir(parents=True)
+    (nested_static / "generated.js").write_text("export const generated = true;\n", encoding="utf-8")
+
+    modules = detect_modules(tmp_path)
+    assert "static" in modules
+
+    loaded = load_module_files(resolve_module_path(tmp_path, "static"), tmp_path)
+
+    assert [item.rel_path for item in loaded] == ["static/app.js"]
+
+
 def test_typescript_grouping_uses_local_import_edges(tmp_path: Path) -> None:
     """Related TS/JS files should group together through semantic import keys."""
     _write_text(


### PR DESCRIPTION
## Summary
- Fixes `engine/antigravity_engine/hub/module_grouping.py` so artifact detection is evaluated relative to the module root.
- Keeps real top-level source modules named `static/` eligible for grouping while still excluding nested generated/static artifact directories.
- Adds a regression test covering a detected top-level `static` module with a nested generated `static` directory.

## Why
A workspace can have a real top-level `static/` source module. The previous artifact check evaluated absolute path parts, so any file under that module was skipped because `static` appeared in the full path. That caused refresh to load zero files for the module and produce no group agents.

## Validation
- `python -m pytest tests/test_hub_module_grouping.py -q` passed: 9 passed.
- `python -m pytest -q` was also run; 219 passed and 5 failed for pre-existing environment/platform reasons unrelated to this patch: missing async pytest plugin handling for `pytest.mark.asyncio` tests and a Windows POSIX permission-mode assertion.
- Local package reinstall from `engine/` with `python -m pip install --user --no-deps --force-reinstall .` succeeded.
- Installed-package regression check confirmed a top-level `static/app.js` loads while `static/nested/static/generated.js` remains excluded.
