### PR TITLE
Handle rg execution failures in memory search

### DIFF
--- a/engine/antigravity_engine/tools/memory_tools.py
+++ b/engine/antigravity_engine/tools/memory_tools.py
@@ -92,8 +92,8 @@ def search_memory_md(
             return completed.stdout.strip()
         if completed.returncode in (0, 1):
             return "No matching memory lines found."
-    except FileNotFoundError:
-        # Fallback for environments without ripgrep installed.
+    except OSError:
+        # Fallback for environments where ripgrep is missing or cannot run.
         pass
 
     matches = []

--- a/engine/tests/test_memory_tools.py
+++ b/engine/tests/test_memory_tools.py
@@ -27,6 +27,30 @@ def test_search_memory_md(tmp_path):
     assert "microsandbox" in result.lower()
 
 
+def test_search_memory_md_falls_back_when_rg_cannot_run(tmp_path, monkeypatch):
+    memory_file = tmp_path / "agent_memory.md"
+    memory_file.write_text(
+        "# Agent Memory Log\n\nMicrosandbox enabled.\nDocker removed.\n",
+        encoding="utf-8",
+    )
+
+    def raise_permission_error(*args, **kwargs):
+        raise PermissionError("rg is not executable")
+
+    monkeypatch.setattr(
+        "antigravity_engine.tools.memory_tools.subprocess.run",
+        raise_permission_error,
+    )
+
+    result = search_memory_md(
+        query="docker",
+        max_results=5,
+        memory_file=str(memory_file),
+    )
+
+    assert "Docker removed." in result
+
+
 def test_search_memory_md_empty_query(tmp_path):
     memory_file = tmp_path / "agent_memory.md"
     memory_file.write_text("any", encoding="utf-8")


### PR DESCRIPTION
## Summary
- fall back to the Python memory search implementation when rg exists but cannot be executed
- add a regression test that simulates PermissionError from subprocess.run

## Why
search_memory_md() already has a Python fallback for environments without ripgrep, but Windows environments can also raise PermissionError when rg.exe is present but blocked from execution. In that case the function crashed instead of using the fallback.

## Validation
- python -m pytest engine/tests/test_memory_tools.py -q