### PR TITLE
Detect src layout Python entry points

### DIFF
--- a/engine/antigravity_engine/hub/scanner.py
+++ b/engine/antigravity_engine/hub/scanner.py
@@ -388,6 +388,7 @@ def _read_entry_points(root: Path, config_contents: dict[str, str]) -> dict[str,
                 for _cmd, ref in scripts.items():
                     mod = ref.split(":")[0].replace(".", "/") + ".py"
                     candidates.append(mod)
+                    candidates.append(f"src/{mod}")
             except Exception:
                 pass
 

--- a/engine/tests/test_hub_scanner.py
+++ b/engine/tests/test_hub_scanner.py
@@ -212,6 +212,20 @@ def test_full_scan_detects_entry_points_from_pyproject(tmp_path: Path) -> None:
     assert "ag_cli/cli.py" in report.entry_points
 
 
+def test_full_scan_detects_src_layout_entry_points_from_pyproject(tmp_path: Path) -> None:
+    """Entry points in src-layout Python packages should be detected."""
+    (tmp_path / "pyproject.toml").write_text(
+        '[project.scripts]\nag = "ag_cli.cli:app"\n', encoding="utf-8"
+    )
+    cli_dir = tmp_path / "src" / "ag_cli"
+    cli_dir.mkdir(parents=True)
+    (cli_dir / "cli.py").write_text("app = 'hello'\n", encoding="utf-8")
+
+    report = full_scan(tmp_path)
+
+    assert "src/ag_cli/cli.py" in report.entry_points
+
+
 def test_full_scan_detects_common_entry_files(tmp_path: Path) -> None:
     """Common entry-point filenames are detected as fallback."""
     (tmp_path / "main.py").write_text("if __name__ == '__main__': pass\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- detect console script modules under both flat and src-layout Python package paths
- add a regression test for pyproject.toml [project.scripts] pointing to src/ag_cli/cli.py

## Why
The scanner used project.scripts entries to infer entry-point files, but only checked flat package paths such as ag_cli/cli.py. Modern Python projects commonly use src layout, including this repository's cli package. When scanning the cli subproject, the entry point was missed and the generated project report lacked the main CLI file.

## Validation
- python -m pytest engine/tests/test_hub_scanner.py -q
- python -m pytest engine/tests/test_hub_pipeline.py::test_format_scan_report_includes_entry_points -q
- Manual scan of the cli subproject returns src/ag_cli/cli.py in report.entry_points