### PR TITLE
docs: remove DolOffer ads from English and Chinese READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,6 @@
 <br/>
 
 <div align="center">
-
-<a href="https://doloffer.com">
-  <img src="docs/assets/doloffer-banner.png" alt="DolOffer - GPT and Claude membership recharge, official subscriptions with after-sales support" width="800"/>
-</a>
-
-<sub><b>Sponsored placement:</b> <a href="https://doloffer.com">DolOffer</a> (<a href="https://github.com/Doloffer-g/guide">GitHub project</a>) offers discounted GPT and Claude membership recharge, official subscriptions, and after-sales support. Use code <code>AI8888</code> for 10% off.</sub><br/>
-<sub><b>Disclaimer:</b> This is a paid sponsor placement. DolOffer services, pricing, availability, and support are provided by DolOffer; please review their terms before purchase.</sub>
-
-</div>
-
-<br/>
-
-<div align="center">
 <img src="docs/assets/before_after.svg" alt="Before vs After RepoBrain" width="800"/>
 </div>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -39,19 +39,6 @@
 <br/>
 
 <div align="center">
-
-<a href="https://doloffer.com">
-  <img src="docs/assets/doloffer-banner-cn.png" alt="DolOffer - GPT 和 Claude 会员充值，正版订阅，售后无忧" width="800"/>
-</a>
-
-<sub><b>赞助位:</b> <a href="https://doloffer.com">DolOffer</a>（<a href="https://github.com/Doloffer-g/guide">GitHub 项目</a>）提供优惠价 GPT / Claude 会员充值，正版订阅，售后无忧。使用优惠码 <code>AI8888</code> 可享 9 折。</sub><br/>
-<sub><b>免责声明:</b> 这是付费赞助展示位。DolOffer 的服务、价格、可用性和售后支持均由 DolOffer 提供，购买前请自行查看其条款。</sub>
-
-</div>
-
-<br/>
-
-<div align="center">
 <img src="docs/assets/before_after.svg" alt="Before vs After RepoBrain" width="800"/>
 </div>
 


### PR DESCRIPTION
### Motivation

- Remove third-party sponsored content (DolOffer banner, promotional copy and disclaimer) from the public README files to keep documentation vendor-neutral and focused on the project.

### Description

- Deleted the DolOffer advertisement block (banner image, sponsored placement text, discount code and disclaimer) from `README.md`.
- Deleted the corresponding DolOffer advertisement block from `README_CN.md`.
- Left surrounding layout and project assets in place so the README flow and images remain intact.

### Testing

- Ran `git diff --check` to validate there are no whitespace or diff errors and it passed.
- Verified with `rg -n -i 'DolOffer|Sponsored placement|AI8888|paid sponsor|赞助位|付费赞助' README.md README_CN.md` that the sponsorship strings are no longer present.
- Confirmed repository status with `git status --short --branch` to ensure the working tree is clean after applying the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a686c03ae188330b082f53fe4711eba)